### PR TITLE
initial PR for vpc-route module

### DIFF
--- a/modules/vpc_routes/README.md
+++ b/modules/vpc_routes/README.md
@@ -1,0 +1,83 @@
+# Base AWS Infrrastructure Resources for VM-Series
+
+## Overview  
+Create VPC, Subnets, Security Groups, Transit Gateways, Route Tables, and other optional resources to support a Palo Alto Networks VM-Series Deployment.
+
+### Usage
+```
+provider "aws" {
+  region = var.region
+}
+
+module "vpc" {
+  source     = "git::https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/modules/vpc?ref=v0.1.0"
+
+prefix_name_tag = "my-prefix"   // Used for resource name Tags. Leave as empty string if not desired
+
+global_tags = {
+ Environment = "us-east-1"
+ Group       = "SecOps"
+ Managed_By  = "Terraform"
+ Description = "Example Usage"
+}
+
+vpc = {
+ vmseries_vpc = {
+  existing              = false
+   name                  = "vmseries-vpc"
+   cidr_block            = "10.100.0.0/16"
+   secondary_cidr_blocks = ["10.200.0.0/16", "10.201.0.0/16"]
+   instance_tenancy      = "default"
+   enable_dns_support    = true
+   enable_dns_hostname   = true
+   igw                   = true
+ }
+}
+
+*subnets = {
+ mgmt-1a       = { existing = false, name = "mgmt-1a", cidr = "10.100.0.0/25", az = "us-east-1a", rt = "mgmt" }            # VM-Series management
+ public-1a     = { name = "public-1a", cidr = "10.100.1.0/25", az = "us-east-1a", rt = "vdss-outside" }    # interface in public subnet for internet
+ mgmt-1b       = { name = "mgmt-1b", cidr = "10.100.0.128/25", az = "us-east-1b", rt = "mgmt" }            # VM-Series management
+ public-1b     = { name = "public-1b", cidr = "10.100.1.128/25", az = "us-east-1b", rt = "vdss-outside" }    # interface in public subnet for internet
+}
+
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.13 |
+| aws | ~> 3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 3 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| global\_tags | Optional Map of arbitrary tags to apply to all resources | `map(any)` | `{}` | no |
+| nat\_gateways | Map of NAT Gateways to create | `any` | `{}` | no |
+| prefix\_name\_tag | Prepended to name tags for various resources. Leave as empty string if not desired. | `string` | `""` | no |
+| security\_groups | Map of Security Groups | `any` | `{}` | no |
+| subnets | Map of Subnets to create | `any` | `{}` | no |
+| vpc | Map of parameters for the VPC. | `any` | `{}` | no |
+| vpc\_endpoints | Map of VPC endpoints | `any` | `{}` | no |
+| vpc\_route\_tables | Map of VPC route Tables to create | `any` | `{}` | no |
+| vpn\_gateways | Map of VGWs to create | `any` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| route\_table\_ids | n/a |
+| subnet\_ids | n/a |
+| vpc | VPC attributes |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpc_routes/examples/all_options/main.tf
+++ b/modules/vpc_routes/examples/all_options/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  required_version = "~> 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.region
+  version = "3.8.0"
+  profile = "default"
+}
+
+############################################################
+# Create Maps of resource name -> ID Mappings to pass to module
+############################################################
+
+
+## Example of creating Route Table Name -> ID map from data lookup based on Name Tag
+data "aws_route_table" "this" {
+  for_each = { 
+    for route in var.vpc_routes : route.route_table => route...
+  }
+  tags = {
+    Name = "${var.prefix_name_tag}${each.key}"
+  }
+}
+
+locals {
+  route_table_ids = {
+    for k, route_table in data.aws_route_table.this :
+    k => route_table.id
+  }
+}
+
+## Example of creating Internet Gateway Name -> ID map from data lookup based on Name Tag
+data "aws_internet_gateway" "this" {
+  for_each = { 
+    for route in var.vpc_routes : route.next_hop_name => route... 
+    if lookup(route, "next_hop_type", null) == "internet_gateway" ? true : false
+  }
+  tags = {
+    Name = "${var.prefix_name_tag}${each.key}"
+  }
+}
+
+locals {
+  internet_gateway_ids = {
+    for k, igw in data.aws_internet_gateway.this :
+    k => igw.id
+  }
+}
+
+## Example of creating Internet Gateway Name -> ID map from data lookup based on Name Tag
+data "aws_vpn_gateway" "this" {
+  for_each = { 
+    for route in var.vpc_routes : route.next_hop_name => route... 
+    if lookup(route, "next_hop_type", null) == "vpn_gateway" ? true : false
+  }
+  tags = {
+    Name = "${var.prefix_name_tag}${each.key}"
+  }
+}
+
+locals {
+  vpn_gateway_ids = {
+    for k, vgw in data.aws_vpn_gateway.this :
+    k => vgw.id
+  }
+}
+
+
+// TODO: Add example of referencing direct reference from VPC module, remote state output, and manually defined map values
+
+
+output "route_tables" {
+  value = local.route_table_ids
+}
+
+output "igws" {
+  value = local.internet_gateway_ids
+}
+
+
+############################################################
+# Call Route module
+############################################################
+
+module "all_options" {
+  source           = "../../"
+  global_tags      = var.global_tags
+  prefix_name_tag  = var.prefix_name_tag
+  vpc_routes       = var.vpc_routes
+  vpc_route_tables = local.route_table_ids
+  internet_gateways     = local.internet_gateway_ids
+  vpn_gateways          = local.vpn_gateway_ids
+}

--- a/modules/vpc_routes/examples/all_options/outputs.tf
+++ b/modules/vpc_routes/examples/all_options/outputs.tf
@@ -1,0 +1,11 @@
+# output "vpc_id" {
+#   value = module.vpc_all_options.vpc
+# }
+
+# output "subnet_ids" {
+#   value = module.vpc_all_options.subnet_ids
+# }
+
+# output "route_table_ids" {
+#   value = module.vpc_all_options.route_table_ids
+# }

--- a/modules/vpc_routes/examples/all_options/terraform.tfvars
+++ b/modules/vpc_routes/examples/all_options/terraform.tfvars
@@ -1,0 +1,38 @@
+region = "us-east-1"
+
+prefix_name_tag = "vpc-all-options-" // Used for resource name Tags. Leave as empty string if not desired
+
+global_tags = {
+  Environment = "us-east-1"
+  Group       = "SecOps"
+  Managed_By  = "Terraform"
+  Description = "Demo of all resource types and optional parameters supported by this module"
+}
+
+
+vpc_routes = {
+  mgmt-igw       = { 
+    route_table = "mgmt"
+    prefix = "0.0.0.0/0"
+    next_hop_type = "internet_gateway"
+    next_hop_name = "igw"
+  }
+  # mgmt-tgw       = { 
+  #   route_table = "mgmt"
+  #   prefix = "10.0.0.0/8"
+  #   next_hop_type = "transit_gateway"
+  #   next_hop_name = "my-tgw"
+  # }
+  mgmt-vgw       = { 
+    route_table = "mgmt"
+    prefix = "172.16.0.0/12"
+    next_hop_type = "vpn_gateway"
+    next_hop_name = "vmseries_vgw"
+  }
+  public-igw       = { 
+    route_table = "public"
+    prefix = "0.0.0.0/0"
+    next_hop_type = "internet_gateway"
+    next_hop_name = "igw"
+  }
+}

--- a/modules/vpc_routes/examples/all_options/variables.tf
+++ b/modules/vpc_routes/examples/all_options/variables.tf
@@ -1,0 +1,45 @@
+# Check module for variable definitions and documentation
+
+variable region {
+  default = ""
+}
+
+variable prefix_name_tag {
+  default = ""
+}
+
+variable global_tags {
+  default = {}
+}
+
+variable vpc_routes {
+  default     = {}
+}
+
+variable vpc_route_tables {
+  default     = {}
+}
+
+variable internet_gateways {
+  default     = {}
+}
+
+variable vpn_gateways {
+  default     = {}
+}
+
+variable nat_gateways {
+  default     = {}
+}
+
+variable transit_gateways {
+  default     = {}
+}
+
+variable vpc_peers {
+  default     = {}
+}
+
+variable interfaces {
+  default     = {}
+}

--- a/modules/vpc_routes/main.tf
+++ b/modules/vpc_routes/main.tf
@@ -1,0 +1,124 @@
+/**
+ * # Base AWS Infrrastructure Resources for VM-Series
+ *
+ * ## Overview
+ * Create VPC, Subnets, Security Groups, Transit Gateways, Route Tables, and other optional resources to support a Palo Alto Networks VM-Series Deployment.
+ * 
+ * 
+ * ### Usage
+ * ```
+ * provider "aws" {
+ *   region = var.region
+ * }
+ * 
+ * module "vpc" {
+ *   source     = "git::https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/modules/vpc?ref=v0.1.0"
+ *
+ * prefix_name_tag = "my-prefix"   // Used for resource name Tags. Leave as empty string if not desired
+ *
+ * global_tags = {
+ *  Environment = "us-east-1"
+ *  Group       = "SecOps"
+ *  Managed_By  = "Terraform"
+ *  Description = "Example Usage"
+ * }
+ *
+ * vpc = {
+ *  vmseries_vpc = {
+ *   existing              = false
+ *    name                  = "vmseries-vpc"
+ *    cidr_block            = "10.100.0.0/16"
+ *    secondary_cidr_blocks = ["10.200.0.0/16", "10.201.0.0/16"]
+ *    instance_tenancy      = "default"
+ *    enable_dns_support    = true
+ *    enable_dns_hostname   = true
+ *    igw                   = true
+ *  }
+ * }
+ *
+ *subnets = {
+ *  mgmt-1a       = { existing = false, name = "mgmt-1a", cidr = "10.100.0.0/25", az = "us-east-1a", rt = "mgmt" }            # VM-Series management
+ *  public-1a     = { name = "public-1a", cidr = "10.100.1.0/25", az = "us-east-1a", rt = "vdss-outside" }    # interface in public subnet for internet
+ *  mgmt-1b       = { name = "mgmt-1b", cidr = "10.100.0.128/25", az = "us-east-1b", rt = "mgmt" }            # VM-Series management
+ *  public-1b     = { name = "public-1b", cidr = "10.100.1.128/25", az = "us-east-1b", rt = "vdss-outside" }    # interface in public subnet for internet
+ * }
+ *
+ * ```
+ * 
+ */
+
+terraform {
+  required_version = "~> 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3"
+    }
+  }
+}
+
+################
+# VPC Routes
+################
+
+# Create route conditional on gateway type variable (igw, tgw, natgw, eni)
+
+resource "aws_route" "internet_gateway" {
+  for_each               = {
+    for k, v in var.vpc_routes : k => v
+    if v.next_hop_type == "internet_gateway"
+  }
+  route_table_id = var.vpc_route_tables[each.value.route_table]
+  destination_cidr_block = each.value.prefix
+  gateway_id  = var.internet_gateways[each.value.next_hop_name]
+}
+
+resource "aws_route" "vpn_gateway" {
+  for_each               = {
+    for k, v in var.vpc_routes : k => v
+    if v.next_hop_type == "vpn_gateway"
+  }
+  route_table_id = var.vpc_route_tables[each.value.route_table]
+  destination_cidr_block = each.value.prefix
+  gateway_id  = var.vpn_gateways[each.value.next_hop_name]
+} 
+
+resource "aws_route" "nat_gateway" {
+  for_each               = {
+    for k, v in var.vpc_routes : k => v
+    if v.next_hop_type == "nat_gateway"
+  }
+  route_table_id = var.vpc_route_tables[each.value.route_table]
+  destination_cidr_block = each.value.prefix
+  nat_gateway_id  = var.nat_gateways[each.value.next_hop_name]
+} 
+
+resource "aws_route" "network_interface" {
+  for_each               = {
+    for k, v in var.vpc_routes : k => v
+    if v.next_hop_type == "interface"
+  }
+  route_table_id = var.vpc_route_tables[each.value.route_table]
+  destination_cidr_block = each.value.prefix
+  network_interface_id  = var.interfaces[each.value.next_hop_name]
+} 
+
+resource "aws_route" "transit_gateway" {
+  for_each               = {
+    for k, v in var.vpc_routes : k => v
+    if v.next_hop_type == "transit_gateway"
+  }
+  route_table_id = var.vpc_route_tables[each.value.route_table]
+  destination_cidr_block = each.value.prefix
+  transit_gateway_id  = var.transit_gateways[each.value.next_hop_name]
+} 
+
+resource "aws_route" "vpc_peer" {
+  for_each               = {
+    for k, v in var.vpc_routes : k => v
+    if v.next_hop_type == "vpc_peer"
+  }
+  route_table_id = var.vpc_route_tables[each.value.route_table]
+  destination_cidr_block = each.value.prefix
+  vpc_peering_connection_id = var.vpc_peers[each.value.next_hop_name]
+} 

--- a/modules/vpc_routes/outputs.tf
+++ b/modules/vpc_routes/outputs.tf
@@ -1,0 +1,15 @@
+# output vpc {
+#   description = "VPC attributes"
+#   value       = local.combined_vpc
+# }
+
+# output subnet_ids {
+#   value = local.combined_subnets
+# }
+
+# output route_table_ids {
+#   value = {
+#     for key, route_table in aws_route_table.this :
+#     key => route_table.id
+#   }
+# }

--- a/modules/vpc_routes/variables.tf
+++ b/modules/vpc_routes/variables.tf
@@ -1,0 +1,59 @@
+variable prefix_name_tag {
+  type        = string
+  default     = ""
+  description = "Prepended to name tags for various resources. Leave as empty string if not desired."
+}
+
+variable global_tags {
+  description = "Optional Map of arbitrary tags to apply to all resources"
+  type        = map(any)
+  default     = {}
+}
+
+variable vpc_routes {
+  description = "Map of Routes to create."
+  type        = any
+  default     = {}
+}
+
+variable vpc_route_tables {
+  description = "Map of Route Table Names to IDs."
+  type        = any
+  default     = {}
+}
+
+variable internet_gateways {
+  description = "Map of Route Table Names to IDs."
+  type        = any
+  default     = {}
+}
+
+variable vpn_gateways {
+  description = "Map of Route Table Names to IDs."
+  type        = any
+  default     = {}
+}
+
+variable nat_gateways {
+  description = "Map of Route Table Names to IDs."
+  type        = any
+  default     = {}
+}
+
+variable transit_gateways {
+  description = "Map of Route Table Names to IDs."
+  type        = any
+  default     = {}
+}
+
+variable vpc_peers {
+  description = "Map of Route Table Names to IDs."
+  type        = any
+  default     = {}
+}
+
+variable interfaces {
+  description = "Map of Route Table Names to IDs."
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
## Description

We need to get our modules merged into develop in their current state as it is difficult to keep everything straight to test interactions between them. This is a stand-alone module for managing route tables inside a VPC. It is separated from base VPC module as these routes will be dependent on other modules.

For example:
Can't create routes to ENI until VM-Series is deployed
Can't create routes to TGW until TGWs are deployed

## How Has This Been Tested?

Tested locally with tf13 using test code included in the module. Also tested with interacting with VPC module. This test will be merged separately

