### PR TITLE
feat(vmseries)!: Rename input attribute `eip` to `eip_name`

### DIFF
--- a/modules/vmseries/examples/vmseries_with_bootstrap_userdata/terraform.tfvars
+++ b/modules/vmseries/examples/vmseries_with_bootstrap_userdata/terraform.tfvars
@@ -102,14 +102,13 @@ interfaces = [
     subnet_name                   = "data1"
     security_group                = "vmseries-data"
     private_ip_address_allocation = "dynamic"
-    eip                           = false
   },
   {
     name                          = "vmseries01-mgmt"
+    eip_name                      = "vmseries01-mgmt"
     source_dest_check             = true
     subnet_name                   = "mgmt1"
     security_group                = "vmseries-mgmt"
     private_ip_address_allocation = "dynamic"
-    eip                           = true
   },
 ]

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -68,14 +68,15 @@ variable prefix_name_tag {
 variable "interfaces" {
   description = "Map of interfaces to create with optional parameters"
   # Required: name, subnet_name, security_group
-  # Optional: eip, source_dest_check
+  # Optional: eip_name, source_dest_check
+  # TODO TERRAM-109: the example below is a confusing `default`, move it to a multiline `description`.
   default = [ # Example
     {
       name              = "ingress-fw1-mgmt"
+      eip_name          = "ingress-fw1-mgmt-eip"
       source_dest_check = true
       subnet_name       = "ingress-mgmt-subnet-az1"
       security_group    = "sg-123456789"
-      eip               = "ingress-fw1-mgmt-eip"
     },
     {
       name              = "ingress-fw1-trust"


### PR DESCRIPTION
## Description

With `eip_name` there is no confusion for users whether to put there a
bool or a string.

Previously an example got it wrong which lead to having two EIPs, one
named "True" and another named... "False" :)

The exclamation mark `!` in the title of this PR means it is a BREAKING CHANGE.

Style: adding an empty line after `for_each` clause.

Style: grouping attributes together.

Refactor: depend on implicit type conversion, remove format() calls.

## How Has This Been Tested?

```
terraform init
terraform apply
```

Default terraform.tfvars, in particular this part:

``` 
interfaces = [
  {
    name                          = "vmseries01-data"   // previously eip = false
    source_dest_check             = false
    subnet_name                   = "data1"
    security_group                = "vmseries-data"
    private_ip_address_allocation = "dynamic"
  },
  {
    name                          = "vmseries01-mgmt"
    eip_name                      = "vmseries01-mgmt"
    source_dest_check             = true
    subnet_name                   = "mgmt1"
    security_group                = "vmseries-mgmt"
    private_ip_address_allocation = "dynamic"
  },
]
```

Terraform will perform the following actions:
 
```
  # module.vmseries.aws_eip.this["vmseries01-data"] will be destroyed
  - resource "aws_eip" "this" {
      - association_id       = "eipassoc-0a265d4cc9030ab17" -> null
      - domain               = "vpc" -> null
      - id                   = "eipalloc-0eae52cf57e1f3bf3" -> null
      - instance             = "i-06ab1d9a836b9ac3b" -> null
      - network_border_group = "us-east-1" -> null
      - network_interface    = "eni-0e9a249051d99abf1" -> null
      - private_dns          = "ip-10-208-4-25.ec2.internal" -> null
      - private_ip           = "10.208.4.25" -> null
      - public_dns           = "ec2-54-225-164-174.compute-1.amazonaws.com" -> null
      - public_ip            = "54.225.164.174" -> null
      - public_ipv4_pool     = "amazon" -> null
      - tags                 = {
          - "Name"       = "false"
          - "managed-by" = "Terraform"
        } -> null
      - vpc                  = true -> null
    }
 
  # module.vmseries.aws_eip.this["vmseries01-mgmt"] will be updated in-place
  ~ resource "aws_eip" "this" {
        association_id       = "eipassoc-0dd6bbf456bf98b54"
        domain               = "vpc"
        id                   = "eipalloc-07715db727a885cf4"
        instance             = "i-06ab1d9a836b9ac3b"
        network_border_group = "us-east-1"
        network_interface    = "eni-00500b20633f54fce"
        private_dns          = "ip-10-208-4-14.ec2.internal"
        private_ip           = "10.208.4.14"
        public_dns           = "ec2-18-213-168-129.compute-1.amazonaws.com"
        public_ip            = "18.213.168.129"
        public_ipv4_pool     = "amazon"
      ~ tags                 = {
          ~ "Name"       = "true" -> "vmseries01-mgmt"
            "managed-by" = "Terraform"
        }
        vpc                  = true
    }
 
  # module.vmseries.aws_eip_association.this["vmseries01-data"] will be destroyed
  - resource "aws_eip_association" "this" {
      - allocation_id        = "eipalloc-0eae52cf57e1f3bf3" -> null
      - id                   = "eipassoc-0a265d4cc9030ab17" -> null
      - instance_id          = "i-06ab1d9a836b9ac3b" -> null
      - network_interface_id = "eni-0e9a249051d99abf1" -> null
      - private_ip_address   = "10.208.4.25" -> null
      - public_ip            = "54.225.164.174" -> null
    }
[...]
Apply complete! Resources: 0 added, 3 changed, 2 destroyed.
```


## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
