### PR TITLE
vpc and subnetset: remove routing_cidrs outputs

### DIFF
--- a/modules/subnet_set/outputs.tf
+++ b/modules/subnet_set/outputs.tf
@@ -21,16 +21,3 @@ output "unique_route_table_ids" {
 output "availability_zones" {
   value = toset(keys(local.input_subnets))
 }
-
-output "routing_cidrs" {
-  description = "Usable for vpc_route module. Example."
-  value = { for k, v in local.subnets :
-    v.cidr_block => "ipv4" if v.cidr_block != null && v.cidr_block != ""
-  }
-}
-
-output "ipv6_routing_cidrs" {
-  value = { for k, v in local.subnets :
-    v.ipv6_cidr_block => "ipv6" if v.ipv6_cidr_block != null && v.ipv6_cidr_block != ""
-  }
-}

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -75,9 +75,7 @@ No modules.
 | <a name="output_igw_as_next_hop_set"></a> [igw\_as\_next\_hop\_set](#output\_igw\_as\_next\_hop\_set) | The object is suitable for use as `vpc_route` module's input `next_hop_set`. |
 | <a name="output_internet_gateway"></a> [internet\_gateway](#output\_internet\_gateway) | The entire Internet Gateway object. It is null when `create_internet_gateway` is false. |
 | <a name="output_internet_gateway_route_table"></a> [internet\_gateway\_route\_table](#output\_internet\_gateway\_route\_table) | The Route Table object created to handle traffic from Internet Gateway (IGW). It is null when `create_internet_gateway` is false. |
-| <a name="output_ipv6_routing_cidrs"></a> [ipv6\_routing\_cidrs](#output\_ipv6\_routing\_cidrs) | Does not have the same limitation as routing\_cidr output. |
 | <a name="output_name"></a> [name](#output\_name) | The VPC Name Tag (either created or pre-existing). |
-| <a name="output_routing_cidrs"></a> [routing\_cidrs](#output\_routing\_cidrs) | Returns the concatenation of `cidr_block` and `secondary_cidr_blocks` inputs. Even when `create_vpc = false` the `data.aws_vpc.cidr_block_associations` will not be usable to build routes on it because of Terraform limitation ('Invalid count argument'). |
 | <a name="output_security_group_ids"></a> [security\_group\_ids](#output\_security\_group\_ids) | Map of Security Group Name -> ID (newly created). |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | The entire VPC object (either created or pre-existing). |
 | <a name="output_vpn_gateway"></a> [vpn\_gateway](#output\_vpn\_gateway) | The entire Virtual Private Gateway object. It is null when `create_vpn_gateway` is false. |

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -41,20 +41,6 @@ output "security_group_ids" {
   }
 }
 
-output "routing_cidrs" {
-  description = "Returns the concatenation of `cidr_block` and `secondary_cidr_blocks` inputs. Even when `create_vpc = false` the `data.aws_vpc.cidr_block_associations` will not be usable to build routes on it because of Terraform limitation ('Invalid count argument')."
-  # Specifically, this fails on provider 3.10 or 3.22:
-  # resource "random_pet" "testing" {
-  #   count = length(data.aws_vpc.this.cidr_block_associations)
-  # }
-  value = { for _, v in concat([var.cidr_block], var.secondary_cidr_blocks) : v => "ipv4" if v != null && v != "" }
-}
-
-output "ipv6_routing_cidrs" {
-  description = "Does not have the same limitation as routing_cidr output."
-  value       = { for _, v in [local.vpc.ipv6_cidr_block] : v => "ipv6" if v != null && v != "" }
-}
-
 output "igw_as_next_hop_set" {
   description = "The object is suitable for use as `vpc_route` module's input `next_hop_set`."
   value = {

--- a/tests/vpc_plan/main.tf
+++ b/tests/vpc_plan/main.tf
@@ -218,25 +218,12 @@ module "vpc_noseccidr" {
 
 resource "random_pet" "consume_maps" {
   for_each = merge(
-    module.vpc.routing_cidrs,
     module.vpc.security_group_ids,
-
-    module.vpc_nosg.routing_cidrs,
     module.vpc_nosg.security_group_ids,
-
-    module.vpc_noseccidr.routing_cidrs,
     module.vpc_noseccidr.security_group_ids,
-
-    module.vpc_noigw.routing_cidrs,
     module.vpc_noigw.security_group_ids,
-
-    module.vpc_useigw.routing_cidrs,
     module.vpc_useigw.security_group_ids,
-
-    module.vpc_novgw.routing_cidrs,
     module.vpc_novgw.security_group_ids,
-
-    module.novpc.routing_cidrs,
     module.novpc.security_group_ids,
   )
 }


### PR DESCRIPTION
## Description

In modules `vpc` and `subnet_set` remove the outputs:
- routing_cidrs 
- ipv6_routing_cidrs

## Motivation and Context

Motivated by the `vpc_plan` tests of the plan stage. They were immediately showing that `ipv6_routing_cidrs` is useless as an output.

While the output could be re-architected somehow together with IPv4 `routing_cidrs`, they are remnants of the idea that is no longer used, superseded by the act_as_next_hop logic. So the most economical things is to remove the outputs until any believable user-story surfaces for them.

By the way, such an immediate return on investment on the `vpc_plan` test! 💯 😮 

## How Has This Been Tested?

Apply of the existing examples according to their READMEs.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
