### PR TITLE
fix subnet_set, stabilize the output subnet_names

### DIFF
--- a/examples/vmseries_combined/vmseries.tf
+++ b/examples/vmseries_combined/vmseries.tf
@@ -29,12 +29,13 @@ module "vmseries" {
   # Because vmseries module does not yet handle subnet_set,
   # convert to a backward compatible map.
   subnets_map = { for v in flatten([for _, set in module.security_subnet_sets :
-    [for _, subnet in set.subnets :
+    [for az, subnet in set.subnets :
       {
-        subnet = subnet
+        subnet_name = set.subnet_names[az]
+        subnet_id   = subnet.id
       }
     ]
-  ]) : v.subnet.tags.Name => v.subnet.id }
+  ]) : v.subnet_name => v.subnet_id }
 }
 
 resource "aws_key_pair" "this" {

--- a/modules/subnet_set/outputs.tf
+++ b/modules/subnet_set/outputs.tf
@@ -7,7 +7,7 @@ output "subnets" {
 }
 
 output "subnet_names" {
-  value = { for k, v in local.subnets : k => try(v.tags.Name, null) }
+  value = { for k, v in local.input_subnets : k => v.name }
 }
 
 output "route_tables" {


### PR DESCRIPTION
## Description

Fix module `subnet_set`, stabilize the output `subnet_names` to be "known".

Other than modification flow, no functionality is changed.

## Motivation and Context

Now when using subnet_names, the example better handles adding new
subnets. Previously adding a third gwlbe_eastwest subnet caused both
VM-Series to be re-created due to all Name tags being "known after
apply".

## How Has This Been Tested?

Apply the `vmseries_combined` example as usual.
Add a third gwlbe_eastwest subnet
```
"10.100.98.0/24" = { az = "us-west-2c", set = "gwlbe_eastwest" }
```
Apply again - check that the ec2 instances were not destroyed and created again.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
