### PR TITLE
fix nat_gateway_set subnets to avoid module call as an object

### DIFF
--- a/examples/single_vpc/main.tf
+++ b/examples/single_vpc/main.tf
@@ -26,7 +26,7 @@ module "subnet_sets" {
 module "nat_gateway_set" {
   source = "../../modules/nat_gateway_set"
 
-  subnet_set = module.subnet_sets["natgw-1"]
+  subnets = module.subnet_sets["natgw-1"].subnets
 }
 
 module "vpc_route" {

--- a/examples/vmseries_combined/main.tf
+++ b/examples/vmseries_combined/main.tf
@@ -29,7 +29,7 @@ module "natgw_set" {
   # This also a "set" and it means the same thing: we will repeat a nat gateway for each subnet (of the subnet_set).
   source = "../../modules/nat_gateway_set"
 
-  subnet_set = module.security_subnet_sets["natgw"]
+  subnets = module.security_subnet_sets["natgw"].subnets
 }
 
 ### TGW ###

--- a/modules/nat_gateway_set/main.tf
+++ b/modules/nat_gateway_set/main.tf
@@ -1,6 +1,5 @@
 locals {
-  eips = var.create_eip ? aws_eip.this : data.aws_eip.this
-  # eips = var.create_eip && var.create_nat_gateway ? aws_eip.this : var.create_nat_gateway ? data.aws_eip.this : {}
+  eips         = var.create_eip ? aws_eip.this : data.aws_eip.this
   nat_gateways = var.create_nat_gateway ? aws_nat_gateway.this : data.aws_nat_gateway.this
 }
 
@@ -8,7 +7,7 @@ locals {
 # Elastic IPs: either new or pre-existing.
 #
 resource "aws_eip" "this" {
-  for_each = var.create_eip && var.create_nat_gateway ? var.subnet_set.subnets : {}
+  for_each = var.create_eip && var.create_nat_gateway ? var.subnets : {}
 
   vpc = true
   tags = merge(
@@ -30,7 +29,7 @@ data "aws_eip" "this" {
 # NAT Gateways: either new or pre-existing.
 #
 resource "aws_nat_gateway" "this" {
-  for_each = var.create_nat_gateway ? var.subnet_set.subnets : {}
+  for_each = var.create_nat_gateway ? var.subnets : {}
 
   allocation_id = local.eips[each.key].id
   subnet_id     = each.value.id
@@ -48,7 +47,7 @@ resource "aws_nat_gateway" "this" {
 }
 
 data "aws_nat_gateway" "this" {
-  for_each = var.create_nat_gateway == false ? var.subnet_set.subnets : {}
+  for_each = var.create_nat_gateway == false ? var.subnets : {}
 
   subnet_id = each.value.id
   state     = "available"

--- a/modules/nat_gateway_set/variables.tf
+++ b/modules/nat_gateway_set/variables.tf
@@ -40,9 +40,26 @@ variable "nat_gateway_names" {
   type        = map(string)
 }
 
-variable "subnet_set" {
-  description = "The subnet set object that owns this NAT Gateway set. The result of the call to the module `subnet_set`, for example `subnet_set = module.natgw_subnet_set`."
-  default     = true
+variable "subnets" {
+  description = <<-EOF
+  Map of Subnets where to create the NAT Gateways. Each map's key is the availability zone name and each map's object has an attribute `id` identifying AWS Subnet. Importantly, the traffic returning from the NAT Gateway uses the Subnet's route table.
+  The keys of this input map are used for the output map `endpoints`.
+  Example for users of module `subnet_set`:
+  ```
+  subnets = module.subnet_set.subnets
+  ```
+  Example:
+  ```
+  subnets = {
+    "us-east-1a" = { id = "snet-123007" }
+    "us-east-1b" = { id = "snet-123008" }
+  }
+  ```
+  EOF
+  type = map(object({
+    id   = string
+    tags = map(string)
+  }))
 }
 
 variable "nat_gateway_tags" {


### PR DESCRIPTION
## Description

Change the input of `nat_gateway_set` module to be `subnets` instead of `subnet_set`.

## Motivation and Context

Avoid the known-bad pattern in the inputs of `nat_gateway_set` module:
https://github.com/PaloAltoNetworks/terraform-best-practices#26-do-not-use-module-calls-as-objects

## How Has This Been Tested?

Apply of examples:  single_vpc and vmseries_combined.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)

Because the nat_gateway_set was not released on any version yet, this breaking change does not impact external users.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
