### PR TITLE
vmseries fix error pending-instance-creation

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -85,6 +85,12 @@ resource "aws_eip_association" "this" {
 
   network_interface_id = aws_network_interface.this[each.key].id
   allocation_id        = aws_eip.this[each.key].id
+
+  depends_on = [
+    # Workaround for:
+    # Error associating EIP: IncorrectInstanceState: The pending-instance-creation instance to which 'eni' is attached is not in a valid state for this operation
+    aws_instance.pa_vm_series
+  ]
 }
 
 


### PR DESCRIPTION
## Description

Fixes #97 
Fixes the recurring error with the `pending-instance-creation` state.

Delay EIP association until all the EC2 instances are fully created.

## How Has This Been Tested?

Multiple deployments of the `vmseries_combined` example.

Modification: removing EIPs on a deployed environment.

Modification: removing VM-Series instances on a deployed environment.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
