### PR TITLE
fix bootstrap rm hardcoded dash

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -3,7 +3,7 @@ resource "random_id" "bucket_id" {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket = "${var.prefix}-${random_id.bucket_id.hex}"
+  bucket = "${var.prefix}${random_id.bucket_id.hex}"
   acl    = "private"
   tags   = var.global_tags
 }
@@ -43,7 +43,7 @@ resource "aws_s3_bucket_object" "bootstrap_files" {
 }
 
 resource "aws_iam_role" "this" {
-  name = "${var.prefix}-${random_id.bucket_id.hex}"
+  name = "${var.prefix}${random_id.bucket_id.hex}"
 
   tags               = var.global_tags
   assume_role_policy = <<EOF
@@ -63,7 +63,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "bootstrap" {
-  name   = "${var.prefix}-${random_id.bucket_id.hex}"
+  name   = "${var.prefix}${random_id.bucket_id.hex}"
   role   = aws_iam_role.this.id
   policy = <<EOF
 {
@@ -85,7 +85,7 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "this" {
-  name = coalesce(var.iam_instance_profile_name, "${var.prefix}-${random_id.bucket_id.hex}")
+  name = coalesce(var.iam_instance_profile_name, "${var.prefix}${random_id.bucket_id.hex}")
   role = aws_iam_role.this.name
   path = "/"
 }

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -1,16 +1,17 @@
 variable "global_tags" {
-  description = "Optional Map of arbitrary tags to apply to all resources."
+  description = "Map of arbitrary tags to apply to all resources."
   default     = {}
   type        = map(any)
 }
 
 variable "prefix" {
-  default = "bootstrap"
-  type    = string
+  description = "The prefix to use for bucket name, IAM role name, and IAM role policy name. It is allowed to use dash \"-\" as the last character."
+  default     = "bootstrap-"
+  type        = string
 }
 
 variable "iam_instance_profile_name" {
-  description = "(optional) Name of the instance profile to create. If empty, name will be generated automatically."
+  description = "Name of the instance profile to create. If empty, name will be auto-generated."
   default     = ""
   type        = string
 }


### PR DESCRIPTION
Do not force the user to always have a dash (hyphen) after the prefix.

This also allows the prefix to be empty.

This is a breaking change, the existing deployment should alter their
prefix to add "-" at the end. Going from this:

prefix = var.bucket_prefix

Recommended to change into:

prefix = "${var.bucket_prefix}-"

Without such code modification, the usual case would be destroying all
bootstrap buckets and all VM-Series, disrupting the traffic.