### PR TITLE
fix modules/bootstrap destroy error

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -3,9 +3,10 @@ resource "random_id" "bucket_id" {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket = "${var.prefix}${random_id.bucket_id.hex}"
-  acl    = "private"
-  tags   = var.global_tags
+  bucket        = "${var.prefix}${random_id.bucket_id.hex}"
+  acl           = "private"
+  force_destroy = var.force_destroy
+  tags          = var.global_tags
 }
 
 resource "aws_s3_bucket_object" "bootstrap_dirs" {

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -16,6 +16,12 @@ variable "iam_instance_profile_name" {
   type        = string
 }
 
+variable "force_destroy" {
+  description = "Set to false to prevent Terraform from destroying a bucket with unknown objects or locked objects."
+  default     = true
+  type        = bool
+}
+
 variable "bootstrap_directories" {
   description = "The directories comprising the bootstrap package."
   default = [


### PR DESCRIPTION
Set `force_destroy` to enable the bucket to be destroyed when it
contains extra files or extra file versions beyond these handled in
Terraform.

If users upload their own files to the bucket during its life, which
happens quite often, proceed with the terraform destroy without this
error:

BucketNotEmpty: The bucket you tried to delete is not empty. You must
delete all versions in the bucket.

If users need to download any files which were put manually (authcodes
come to mind, etc.), they need to do so before destroying the bucket.
Otherwise the data will be lost.
