### PR TITLE
detect re-creation of resources in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/PaloAltoNetworks/terraform-aws-vmseries-modules
 
 go 1.14
 
-require github.com/gruntwork-io/terratest v0.35.7
+require (
+	github.com/gruntwork-io/terratest v0.35.7
+	github.com/hashicorp/terraform-json v0.9.0
+)


### PR DESCRIPTION
Assume a new testing convention: any `terraform apply` run (any of the
multiple such runs in a test case) is considered failed if any single resource
was replaced (i.e. destroyed and then re-created). Thus if you want to
explicitly test replacing a resource, split it into two test-cases:

- Can a resource be added to an existing deployment?
- Can a resource be destroyed in an existing deployment?

Why: For any of these two test-case types, it is a very rarely desired
to see any resource replaced.
But a frequent situation is that the resources are replaced in an
unexpected way and the availability/traffic suffers.

The test which replaces the entire resource is usually decomposable
into two tests - whether one can add a resource and wheter one can
destroy a resource.

Exempt the resources that do not impact data traffic.