### PR TITLE
gitignore .terragrunt-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 .terraform.d
 *.tfstate
 *.tfstate.*
+.terragrunt-cache
 .vscode
 .idea
 .idea


### PR DESCRIPTION
Provide for easier introduction of terragrunt.
The .terragrunt-cache contains quite a large number of files and should
not be committed to git.