### PR TITLE
in app1_ec2 change the VM to bitnami ready-made nginx

### DIFF
--- a/examples/tgw_inbound_combined_with_gwlb/README.md
+++ b/examples/tgw_inbound_combined_with_gwlb/README.md
@@ -102,7 +102,7 @@ In a nutshell it means:
 
 | Name | Description |
 |------|-------------|
-| <a name="output_app1_inspected_dns_name"></a> [app1\_inspected\_dns\_name](#output\_app1\_inspected\_dns\_name) | The DNS name that you can use to SSH into a testbox. Use `ssh ubuntu@<<value>>` command with the same public key as given in the `ssh_public_key_file_path` input. |
+| <a name="output_app1_inspected_dns_name"></a> [app1\_inspected\_dns\_name](#output\_app1\_inspected\_dns\_name) | The DNS name that you can use to SSH into a testbox. Use username `bitnami` and the private key matching the public key configured with the input `ssh_public_key_file_path`. |
 | <a name="output_app1_inspected_public_ip"></a> [app1\_inspected\_public\_ip](#output\_app1\_inspected\_public\_ip) | The IP address behind the `app1_inspected_dns_name`. |
 | <a name="output_security_gwlb_service_name"></a> [security\_gwlb\_service\_name](#output\_security\_gwlb\_service\_name) | The AWS Service Name of the created GWLB, which is suitable to use for subsequent VPC Endpoints. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/tgw_inbound_combined_with_gwlb/app1_spoke.tf
+++ b/examples/tgw_inbound_combined_with_gwlb/app1_spoke.tf
@@ -80,20 +80,15 @@ module "app1_route" {
 ### App1 EC2 instance ###
 
 data "aws_ami" "this" {
-  most_recent = true
+  most_recent = true # newest by time, not by version number
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["bitnami-nginx-1.21*-linux-debian-10-x86_64-hvm-ebs-nami"]
     # The wildcard '*' causes re-creation of the whole EC2 instance when a new image appears.
   }
 
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["099720109477"]
+  owners = ["979382823631"] # bitnami = 979382823631
 }
 
 module "app1_ec2" {

--- a/examples/tgw_inbound_combined_with_gwlb/outputs.tf
+++ b/examples/tgw_inbound_combined_with_gwlb/outputs.tf
@@ -8,7 +8,7 @@ output "security_gwlb_service_name" {
 ##### App1 VPC #####
 
 output "app1_inspected_dns_name" {
-  description = "The DNS name that you can use to SSH into a testbox. Use `ssh ubuntu@<<value>>` command with the same public key as given in the `ssh_public_key_file_path` input."
+  description = "The DNS name that you can use to SSH into a testbox. Use username `bitnami` and the private key matching the public key configured with the input `ssh_public_key_file_path`."
   value       = module.app1_lb.lb_dns_name
 }
 


### PR DESCRIPTION
The bitnami library offers a ready-made http/https server, which saves
time during testing. On the previous ubuntu image, the path to have
https was unneccessarily bumpy:
- the inbound ssh needed to work
- the user needed ssh/putty locally
- apt update
- apt install ngnix
- for these commands, the outbound also always needed to work, yet
another difficulty.

All these steps are not needed with a ready-made image.

The bitnami image is free of cost as well.