### PR TITLE
feat(vmseries): add output `network_interfaces`

### DIFF
--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -83,4 +83,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_firewalls"></a> [firewalls](#output\_firewalls) | n/a |
+| <a name="output_network_interfaces"></a> [network\_interfaces](#output\_network\_interfaces) | n/a |
+| <a name="output_raw_network_interfaces"></a> [raw\_network\_interfaces](#output\_raw\_network\_interfaces) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vmseries/outputs.tf
+++ b/modules/vmseries/outputs.tf
@@ -4,3 +4,16 @@ output "firewalls" {
     k => f
   }
 }
+
+output "raw_network_interfaces" {
+  value = aws_network_interface.this
+}
+
+output "network_interfaces" {
+  value = { for k, v in local.interfaces : k => merge(v,
+    {
+      id         = aws_network_interface.this[k].id
+      private_ip = aws_network_interface.this[k].private_ip
+    })
+  }
+}


### PR DESCRIPTION
The output is usable for a Load Balancer Target Group working in `"ip"`
mode instead of the usual `"instance"` mode (the `target_type` input).

The `"ip"` mode is specifically required for panos overlay routing
scenarios. Generally, it is required for loadbalancing any non-primary
interface of a VM on EC2.