### PR TITLE
feat(vpc_endpoint): add a new module `vpc_endpoint`

### DIFF
--- a/examples/vpc_endpoint/README.md
+++ b/examples/vpc_endpoint/README.md
@@ -1,0 +1,8 @@
+# AWS VPC Endpoints Example
+
+This example presents various AWS VPC Endpoints that are potentially usable for
+general VM-Series examples.
+
+The Gateway Load Balancer Endpoint (GWLBE) is a specific type of VPC Endpoint
+which is **not covered** by this example, as it already constitues the core of
+many VM-Series examples, like `tgw_inbound_combined_with_gwlb`.

--- a/examples/vpc_endpoint/example.tfvars
+++ b/examples/vpc_endpoint/example.tfvars
@@ -1,0 +1,13 @@
+region = "us-east-1"
+
+global_tags = {
+  ManagedBy   = "terraform"
+  Application = "Palo Alto Networks VM-Series Combined"
+  Owner       = "PS team"
+  Creator     = "login"
+}
+
+
+security_vpc_name = "security-vpc"
+security_vpc_cidr = "10.100.0.0/16"
+

--- a/examples/vpc_endpoint/main.tf
+++ b/examples/vpc_endpoint/main.tf
@@ -1,0 +1,89 @@
+module "vpc" {
+  source = "../../modules/vpc"
+
+  name                    = var.security_vpc_name
+  cidr_block              = "10.100.0.0/16"
+  create_internet_gateway = false
+  global_tags             = var.global_tags
+  security_groups = {
+    vpc_endpoint = {
+      name       = "vpc_endpoint"
+      local_tags = { "foo" = "bar" }
+      rules = {
+        all_outbound = {
+          description = "Permit All traffic outbound"
+          type        = "egress", from_port = "0", to_port = "0", protocol = "-1"
+          cidr_blocks = ["0.0.0.0/0"]
+        }
+        https_inbound = {
+          description = "Permit HTTPS from mgmt subnets"
+          type        = "ingress", from_port = "443", to_port = "443", protocol = "tcp"
+          cidr_blocks = ["10.100.0.0/25", "10.100.64.0/25"]
+        }
+      }
+    }
+  }
+}
+
+#
+# A set of subnets to operate on, named "mgmt" and spread between two availability zones.
+#
+module "subnet_set_mgmt" {
+  source = "../../modules/subnet_set"
+
+  name                = "${var.security_vpc_name}mgmt"
+  vpc_id              = module.vpc.id
+  has_secondary_cidrs = module.vpc.has_secondary_cidrs
+  global_tags         = var.global_tags
+  cidrs = {
+    "10.100.0.0/25"  = { az = "us-east-1a" }
+    "10.100.64.0/25" = { az = "us-east-1b" }
+  }
+}
+
+#
+# PrivateLink to the Amazon EC2 API.
+#
+# In other words, network interfaces that can, for example, understand https API call to AWS to reboot an EC2 instance.
+#
+module "ec2api_endpoint" {
+  source = "../../modules/vpc_endpoint"
+
+  name                = "ec2api-endpoint"
+  simple_service_name = "ec2"
+  type                = "Interface"
+  vpc_id              = module.vpc.id
+  security_group_ids  = [module.vpc.security_group_ids["vpc_endpoint"]]
+  subnets             = module.subnet_set_mgmt.subnets
+  private_dns_enabled = false
+  tags                = merge(var.global_tags, { Description = "PrivateLink to the Amazon EC2 API." })
+}
+
+#
+# PrivateLink to the Amazon API Gateway.
+#
+module "apigw_endpoint" {
+  source = "../../modules/vpc_endpoint"
+
+  name                = "apigw-endpoint"
+  simple_service_name = "execute-api"
+  type                = "Interface"
+  vpc_id              = module.vpc.id
+  security_group_ids  = [module.vpc.security_group_ids["vpc_endpoint"]]
+  subnets             = module.subnet_set_mgmt.subnets
+}
+
+#
+# Routing to S3 which does not traverse the public Internet.
+#
+module "s3_endpoint" {
+  source = "../../modules/vpc_endpoint"
+
+  name                = "s3-endpoint"
+  simple_service_name = "s3"
+  type                = "Gateway"
+  vpc_id              = module.vpc.id
+
+  # The "Gateway" endpoint accepts identifiers of route tables instead of subnets.
+  route_table_ids = module.subnet_set_mgmt.unique_route_table_ids
+}

--- a/examples/vpc_endpoint/variables.tf
+++ b/examples/vpc_endpoint/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  default = "us-east-1"
+}
+
+variable "global_tags" {
+  default = {}
+}
+
+variable "security_vpc_name" {
+  type = string
+}

--- a/examples/vpc_endpoint/versions.tf
+++ b/examples/vpc_endpoint/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.13.7, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 3.10"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/modules/vpc_endpoint/main.tf
+++ b/modules/vpc_endpoint/main.tf
@@ -1,0 +1,53 @@
+# Be friendly, attempt to use the simplified service name ("s3") to find out a real one ("com.amazonaws.us-west-2.s3").
+data "aws_vpc_endpoint_service" "this" {
+  count = var.simple_service_name != null ? 1 : 0
+
+  service      = var.simple_service_name
+  service_type = var.type
+}
+
+#
+# Convenient combined object, it is either a `resource` object or a `data` object.
+#
+locals {
+  vpc_endpoint = var.create ? aws_vpc_endpoint.this[0] : data.aws_vpc_endpoint.this[0]
+}
+
+resource "aws_vpc_endpoint" "this" {
+  count = var.create ? 1 : 0
+
+  vpc_id              = var.vpc_id
+  service_name        = var.simple_service_name != null ? data.aws_vpc_endpoint_service.this[0].service_name : var.service_name
+  vpc_endpoint_type   = var.type
+  auto_accept         = var.auto_accept
+  policy              = var.policy
+  private_dns_enabled = var.private_dns_enabled
+  security_group_ids  = var.security_group_ids
+  tags                = merge(var.tags, { Name = coalesce(var.name, var.simple_service_name, var.service_name) })
+}
+
+data "aws_vpc_endpoint" "this" {
+  count = var.create == false ? 1 : 0
+
+  vpc_id       = var.vpc_id
+  service_name = var.simple_service_name != null ? data.aws_vpc_endpoint_service.this[0].service_name : var.service_name
+  tags         = merge(var.tags, { Name = var.name })
+  filter {
+    name   = "vpc-endpoint-type"
+    values = [var.type]
+  }
+}
+
+resource "aws_vpc_endpoint_subnet_association" "this" {
+  for_each = var.subnets
+
+  vpc_endpoint_id = local.vpc_endpoint.id
+  subnet_id       = each.value.id
+}
+
+resource "aws_vpc_endpoint_route_table_association" "this" {
+  for_each = var.route_table_ids
+
+  vpc_endpoint_id = local.vpc_endpoint.id
+  route_table_id  = each.value
+}

--- a/modules/vpc_endpoint/outputs.tf
+++ b/modules/vpc_endpoint/outputs.tf
@@ -1,0 +1,4 @@
+output "endpoint" {
+  description = "The created `aws_vpc_endpoint` object. Alternatively, the data resource if the input `create` is false."
+  value       = local.vpc_endpoint
+}

--- a/modules/vpc_endpoint/variables.tf
+++ b/modules/vpc_endpoint/variables.tf
@@ -1,0 +1,93 @@
+variable "name" {
+  default = null
+  type    = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "type" {
+  description = <<-EOF
+  The type of the service.
+  The type "Gateway" does not tolerate inputs `subnets`,  `security_group_ids`, and `private_dns_enabled`.
+  The type "Interface" does not tolerate input `route_table_ids`.
+  The type "GatewayLoadBalancer" is similar to "Gateway", but can be deployed with the dedicated module `gwlb_endpoint_set`.
+  If null, "Gateway" is used by default.
+  EOF
+  type        = string
+}
+
+variable "create" {
+  description = "If false, does not create a new AWS VPC Endpoint, but instead uses a pre-existing one. The inputs `name`, `service_name`, `simple_service_name`, `tags`, `type`, and `vpc_id` can be used to match the pre-existing endpoint."
+  default     = true
+  type        = bool
+}
+
+variable "service_name" {
+  description = "The exact service name. This input is ignored if `simple_service_name` is defined. Typically \"com.amazonaws.<region>.<service>\", for example: \"com.amazonaws.us-west-2.s3\""
+  default     = null
+  type        = string
+}
+
+variable "simple_service_name" {
+  description = "The simplified service name for AWS service, for example: \"s3\". Uses the service from the current region. If null, the `service_name` input is used instead."
+  default     = null
+  type        = string
+}
+
+variable "auto_accept" {
+  description = "If a service connection requires service owner's acceptance, the request will be approved automatically, provided that both parties are members of the same AWS account."
+  default     = null
+  type        = bool
+}
+
+variable "policy" {
+  default = null
+  type    = string
+}
+
+variable "private_dns_enabled" {
+  default = null
+  type    = bool
+}
+
+variable "security_group_ids" {
+  default = []
+  type    = list(string)
+}
+
+variable "subnets" {
+  # Description identical as in modules/gwlb_endpoint_set:
+  description = <<-EOF
+  Map of Subnets where to create the Endpoints. Each map's key is the availability zone name and each map's object has an attribute
+  `id` identifying AWS Subnet. Importantly, the traffic returning from the Endpoint uses the Subnet's route table.
+  The keys of this input map are used for the output map `endpoints`.
+  Example for users of module `subnet_set`:
+  ```
+  subnets = module.subnet_set.subnets
+  ```
+  Example:
+  ```
+  subnets = {
+    "us-east-1a" = { id = "snet-123007" }
+    "us-east-1b" = { id = "snet-123008" }
+  }
+  ```
+  EOF
+  default     = {}
+  type = map(object({
+    id = string
+  }))
+}
+
+variable "route_table_ids" {
+  default = {}
+  type    = map(string)
+}
+
+variable "tags" {
+  default = {}
+  type    = map(string)
+}
+

--- a/modules/vpc_endpoint/versions.tf
+++ b/modules/vpc_endpoint/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13.7, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.10"
+    }
+  }
+}


### PR DESCRIPTION
The module handles general VPC endpoints of both types, the Gateway
ones (like S3) and the Interface ones (like the REST APIs).

The module is not intended for GWLB Endpoints, for these there is a
separate module `gwlb_endpoint_set`.

Input descriptions co-authored by michalbil.

Co-authored-by: michalbil <92343355+michalbil@users.noreply.github.com>

commit-id:37edddeb