### PR TITLE
fix(docs): correct dead links in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ For copyright and license see the LICENSE file.
 
 This repository has the following directory structure:
 
-* [modules](./modules): This directory contains several standalone, reusable, production-grade Terraform modules. Each module is individually documented.
-* [examples](./examples): This directory shows examples of different ways to combine the modules contained in the
+* `modules` - this directory contains several standalone, reusable, production-grade Terraform modules. Each module is individually documented.
+* `examples` - this directory shows examples of different ways to combine the modules contained in the
   `modules` directory.
 
 ## Compatibility
@@ -31,16 +31,16 @@ We are maintaining a [public roadmap](https://github.com/orgs/PaloAltoNetworks/p
 ## Versioning
 
 These modules follow the principles of [Semantic Versioning](http://semver.org/). You can find each new release,
-along with the changelog, on the GitHub [Releases](../../releases) page.
+along with the changelog, on the GitHub [Releases](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/releases) page.
 
 ## Getting Help
 
-[Open an issue](../../issues) on Github.
+[Open an issue](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/issues) on Github.
 
 ## Contributing
 
 Contributions are welcome, and they are greatly appreciated! Every little bit helps,
-and credit will always be given. Please follow our [contributing guide](./docs/contributing.md).
+and credit will always be given. Please follow our contributing guide.
 
 <!-- ## Who maintains these modules?
 


### PR DESCRIPTION
Non-absolute links are dead in Terraform Registry
Fixes #152

## Description

#152 

## Motivation and Context

Invalid links should not exist in Terraform Registry

## How Has This Been Tested?

n/a

## Screenshots (if appropriate)

n/a

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
