### PR TITLE
feat(vmseries): add output `network_interfaces`

### DIFF
--- a/examples/tgw_inbound_combined_with_gwlb/README.md
+++ b/examples/tgw_inbound_combined_with_gwlb/README.md
@@ -102,7 +102,7 @@ In a nutshell it means:
 
 | Name | Description |
 |------|-------------|
-| <a name="output_app1_inspected_dns_name"></a> [app1\_inspected\_dns\_name](#output\_app1\_inspected\_dns\_name) | The DNS name that you can use to SSH into a testbox. Use `ssh ubuntu@<<value>>` command with the same public key as given in the `ssh_public_key_file_path` input. |
+| <a name="output_app1_inspected_dns_name"></a> [app1\_inspected\_dns\_name](#output\_app1\_inspected\_dns\_name) | The DNS name that you can use to SSH into a testbox. Use username `bitnami` and the private key matching the public key configured with the input `ssh_public_key_file_path`. |
 | <a name="output_app1_inspected_public_ip"></a> [app1\_inspected\_public\_ip](#output\_app1\_inspected\_public\_ip) | The IP address behind the `app1_inspected_dns_name`. |
 | <a name="output_security_gwlb_service_name"></a> [security\_gwlb\_service\_name](#output\_security\_gwlb\_service\_name) | The AWS Service Name of the created GWLB, which is suitable to use for subsequent VPC Endpoints. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/tgw_inbound_combined_with_gwlb/app1_spoke.tf
+++ b/examples/tgw_inbound_combined_with_gwlb/app1_spoke.tf
@@ -145,11 +145,21 @@ module "app1_lb" {
       protocol           = "TCP"
       target_group_index = 0
     },
+    {
+      port               = 80
+      protocol           = "TCP"
+      target_group_index = 1
+    },
+    {
+      port               = 443
+      protocol           = "TCP"
+      target_group_index = 2
+    },
   ]
 
   target_groups = [
     {
-      name_prefix          = "tg0"
+      name                 = "app1-tcp-22"
       backend_protocol     = "TCP"
       backend_port         = 22
       target_type          = "instance"
@@ -160,7 +170,33 @@ module "app1_lb" {
           port      = 22
         }
       }
-    }
+    },
+    {
+      name                 = "app1-tcp-80"
+      backend_protocol     = "TCP"
+      backend_port         = 80
+      target_type          = "instance"
+      deregistration_delay = 10
+      targets = {
+        my_ec2 = {
+          target_id = try(module.app1_ec2.id[0], null)
+          port      = 80
+        }
+      }
+    },
+    {
+      name                 = "app1-tcp-443"
+      backend_protocol     = "TCP"
+      backend_port         = 443
+      target_type          = "instance"
+      deregistration_delay = 10
+      targets = {
+        my_ec2 = {
+          target_id = try(module.app1_ec2.id[0], null)
+          port      = 443
+        }
+      }
+    },
   ]
 
   tags = var.global_tags

--- a/examples/tgw_inbound_combined_with_gwlb/app1_spoke.tf
+++ b/examples/tgw_inbound_combined_with_gwlb/app1_spoke.tf
@@ -80,20 +80,15 @@ module "app1_route" {
 ### App1 EC2 instance ###
 
 data "aws_ami" "this" {
-  most_recent = true
+  most_recent = true # newest by time, not by version number
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["bitnami-nginx-1.21*-linux-debian-10-x86_64-hvm-ebs-nami"]
     # The wildcard '*' causes re-creation of the whole EC2 instance when a new image appears.
   }
 
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["099720109477"]
+  owners = ["979382823631"] # bitnami = 979382823631
 }
 
 module "app1_ec2" {

--- a/examples/tgw_inbound_combined_with_gwlb/outputs.tf
+++ b/examples/tgw_inbound_combined_with_gwlb/outputs.tf
@@ -8,7 +8,7 @@ output "security_gwlb_service_name" {
 ##### App1 VPC #####
 
 output "app1_inspected_dns_name" {
-  description = "The DNS name that you can use to SSH into a testbox. Use `ssh ubuntu@<<value>>` command with the same public key as given in the `ssh_public_key_file_path` input."
+  description = "The DNS name that you can use to SSH into a testbox. Use username `bitnami` and the private key matching the public key configured with the input `ssh_public_key_file_path`."
   value       = module.app1_lb.lb_dns_name
 }
 

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -83,4 +83,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_firewalls"></a> [firewalls](#output\_firewalls) | n/a |
+| <a name="output_network_interfaces"></a> [network\_interfaces](#output\_network\_interfaces) | n/a |
+| <a name="output_raw_network_interfaces"></a> [raw\_network\_interfaces](#output\_raw\_network\_interfaces) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vmseries/outputs.tf
+++ b/modules/vmseries/outputs.tf
@@ -4,3 +4,16 @@ output "firewalls" {
     k => f
   }
 }
+
+output "raw_network_interfaces" {
+  value = aws_network_interface.this
+}
+
+output "network_interfaces" {
+  value = { for k, v in local.interfaces : k => merge(v,
+    {
+      id         = aws_network_interface.this[k].id
+      private_ip = aws_network_interface.this[k].private_ip
+    })
+  }
+}


### PR DESCRIPTION
The output is usable for a Load Balancer Target Group working in `"ip"`
mode instead of the usual `"instance"` mode (the `target_type` input).

The `"ip"` mode is specifically required for panos overlay routing
scenarios. Generally, it is required for loadbalancing any non-primary
interface of a VM on EC2.

commit-id:b7436653