### PR TITLE
fix example, remove files/plugins/.keep

### DIFF
--- a/examples/tgw_inbound_combined_with_gwlb/files/plugins/.keep
+++ b/examples/tgw_inbound_combined_with_gwlb/files/plugins/.keep
@@ -1,1 +1,0 @@
-Do not delete this directory.


### PR DESCRIPTION
The ".keep" despite being a hidden dotfile is detected as a possible
plugin and fails the entire bootstrap with:

Plugin upgrade failed due to invalid image .keep