### PR TITLE
feat(transit_gateway_peering): add a new module `transit_gateway_peering`

### DIFF
--- a/examples/transit_gateway_peering/main.tf
+++ b/examples/transit_gateway_peering/main.tf
@@ -1,0 +1,60 @@
+### eu-west-3 ###
+
+provider "aws" {
+  region = "eu-west-3"
+}
+
+module "transit_gateway" {
+  source = "../../modules/transit_gateway"
+
+  name = "${var.prefix_name_tag}west-tgw"
+  asn  = 65001
+  route_tables = {
+    "from_security_vpc" = {
+      create = true
+      name   = "${var.prefix_name_tag}from_security"
+    }
+    "from_spoke_vpc" = {
+      create = true
+      name   = "${var.prefix_name_tag}from_spokes"
+    }
+  }
+}
+
+### eu-north-1 ###
+
+provider "aws" {
+  alias  = "north"
+  region = "eu-north-1"
+}
+
+module "transit_gateway_north" {
+  source = "../../modules/transit_gateway"
+  providers = {
+    aws = aws.north
+  }
+
+  name = "${var.prefix_name_tag}north-tgw"
+  asn  = 65000
+  route_tables = {
+    "from_spoke_vpc" = {
+      create = true
+      name   = "${var.prefix_name_tag}from_spokes"
+    }
+  }
+}
+
+### cross-region ###
+
+module "transit_gateway_peering" {
+  source = "../../modules/transit_gateway_peering"
+  providers = {
+    aws      = aws
+    aws.peer = aws.north
+  }
+
+  local_tgw_route_table = module.transit_gateway.route_tables["from_spoke_vpc"]
+  peer_tgw_route_table  = module.transit_gateway_north.route_tables["from_spoke_vpc"]
+
+  local_attachment_tags = { Name = "west-to-north-attach" }
+}

--- a/examples/transit_gateway_peering/routes.tf
+++ b/examples/transit_gateway_peering/routes.tf
@@ -1,0 +1,22 @@
+# Optional routes across the peering.
+# Currently AWS only supports static routes, and not propagations, across a peering.
+#
+# As an example, assume:
+#   - the west hosts a VPC named "security"
+#   - the north hosts a spoke VPC named "panorama"
+
+resource "aws_ec2_transit_gateway_route" "from_panorama_to_west" {
+  provider = aws.north
+
+  destination_cidr_block         = "10.0.0.0/8"
+  transit_gateway_route_table_id = module.transit_gateway_north.route_tables["from_spoke_vpc"].id
+  transit_gateway_attachment_id  = module.transit_gateway_peering.peering_attachment.id
+  blackhole                      = false
+}
+
+resource "aws_ec2_transit_gateway_route" "from_security_to_north" {
+  destination_cidr_block         = "10.244.0.0/16"
+  transit_gateway_route_table_id = module.transit_gateway.route_tables["from_security_vpc"].id
+  transit_gateway_attachment_id  = module.transit_gateway_peering.peering_attachment.id
+  blackhole                      = false
+}

--- a/examples/transit_gateway_peering/variables.tf
+++ b/examples/transit_gateway_peering/variables.tf
@@ -1,0 +1,5 @@
+variable "prefix_name_tag" {
+  description = "Prefix for the AWS Name tags of all the created resources."
+  default     = ""
+  type        = string
+}

--- a/examples/transit_gateway_peering/versions.tf
+++ b/examples/transit_gateway_peering/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13.7, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 3.50" # Could be moved down as far as 3.24.1 probably, which contains https://github.com/hashicorp/terraform-provider-aws/issues/15474
+    }
+  }
+}

--- a/modules/transit_gateway_peering/README.md
+++ b/modules/transit_gateway_peering/README.md
@@ -1,0 +1,76 @@
+# AWS Transit Gateway Peering
+
+## Usage
+
+This module creates both sides of a TGW Peering thus it needs two different AWS providers specified in the `providers` meta-argument.
+Without two providers it would be impossible to peer between two distinct AWS regions.
+
+The local side requires the provider entry named `aws`, the remote peer side requires the provider entry named `aws.peer`. The attachment
+is owned by the local side, and the attachment acceptor is owned by the remote side.
+
+```hcl2
+module transit_gateway_peering {
+  source = "../../modules/transit_gateway_peering"
+  providers = {
+    aws      = aws.east
+    aws.peer = aws.west
+  }
+
+  local_tgw_route_table = module.transit_gateway_east.route_tables["traffic_from_west"]
+  peer_tgw_route_table  = module.transit_gateway_west.route_tables["traffic_from_east"]
+}
+
+provider "aws" {
+  alias  = "east"
+  region = "us-east-2"
+}
+
+provider "aws" {
+  alias  = "west"
+  region = "us-west-2"
+}
+```
+
+The static routes are currently not handled by this module.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ec2_transit_gateway_peering_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment) | resource |
+| [aws_ec2_transit_gateway_peering_attachment_accepter.peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment_accepter) | resource |
+| [aws_ec2_transit_gateway_route_table_association.local](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
+| [aws_ec2_transit_gateway_route_table_association.peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
+| [aws_caller_identity.peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.peer_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_local_attachment_tags"></a> [local\_attachment\_tags](#input\_local\_attachment\_tags) | AWS tags to assign to the Attachment object. The tags are only visible in the UI when logged on the local account, but not on the remote peer account. Example: `{ Name = "my-name" }` | `map(string)` | `{}` | no |
+| <a name="input_local_tgw_route_table"></a> [local\_tgw\_route\_table](#input\_local\_tgw\_route\_table) | Local TGW's pre-existing route table which should handle the traffic coming from the peered TGW (also called a route table association). An object with two attributes, the `id` of the local route table and the `transit_gateway_id` of the local TGW:<pre>transit_gateway_route_table = {<br>  id                 = "tgw-rtb-1234"<br>  transit_gateway_id = "tgw-1234"<br>}</pre> | <pre>object({<br>    id                 = string<br>    transit_gateway_id = string<br>  })</pre> | n/a | yes |
+| <a name="input_peer_tgw_route_table"></a> [peer\_tgw\_route\_table](#input\_peer\_tgw\_route\_table) | Analog to the `local_tgw_route_table` but on the remote end of the peering. | <pre>object({<br>    id                 = string<br>    transit_gateway_id = string<br>  })</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | AWS tags to assign to all the created objects. Example: `{ Team = "my-team" }` | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_local_route_table"></a> [local\_route\_table](#output\_local\_route\_table) | The route table associated to the TGW Peering Attachment, owned by the provider `aws`. |
+| <a name="output_peer_route_table"></a> [peer\_route\_table](#output\_peer\_route\_table) | The route table associated to the TGW Peering Attachment, owned by the provider `aws.peer`. |
+| <a name="output_peering_attachment"></a> [peering\_attachment](#output\_peering\_attachment) | The TGW Peering Attachment object, created under the provider `aws`. |
+| <a name="output_peering_attachment_accepter"></a> [peering\_attachment\_accepter](#output\_peering\_attachment\_accepter) | The Accepter object, created under the provider `aws.peer`. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/transit_gateway_peering/main.tf
+++ b/modules/transit_gateway_peering/main.tf
@@ -1,0 +1,59 @@
+# Why are resource split between module `transit_gateway` and `transit_gateway_peering`?
+#
+# With TGW peering, the module which creates an Attachment needs to see first *both* TGWs completed.
+# And then, Accepter needs to see the Attachment completed.
+# Hence Accepter cannot be created in the same module as its TGW, because the module first needs
+# to emit the TGW identifier and then wait for Attachment identifier to become usable.
+# Since both the Route Tables can be only associated after the Accepter finishes, the dependency
+# hassle is minimized by putting together Peering Attachment + Peering Accepter + Peering Route Tables
+# in the same module.
+# The downside of this choice is that the resulting module needs two AWS providers, not one.
+
+##### Request from the "local" region to the "peer" region #####
+
+resource "aws_ec2_transit_gateway_peering_attachment" "this" {
+  peer_account_id         = data.aws_caller_identity.peer.account_id
+  peer_region             = data.aws_region.peer_region.name
+  peer_transit_gateway_id = var.peer_tgw_route_table.transit_gateway_id
+  transit_gateway_id      = var.local_tgw_route_table.transit_gateway_id
+  tags                    = merge(var.tags, var.local_attachment_tags)
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "local" {
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_peering_attachment.this.id
+  transit_gateway_route_table_id = var.local_tgw_route_table.id
+
+  # Workaround for apply error "IncorrectState: tgw-attach-1 is in invalid state" (i.e. unaccepted).
+  depends_on = [aws_ec2_transit_gateway_peering_attachment_accepter.peer]
+}
+
+# The aws_ec2_transit_gateway_route_table_propagation here wouldn't be supported by AWS, failing with:
+# "You cannot propagate a peering attachment to a Transit Gateway Route Table".
+
+##### Accept from the "peer" region to the "local" region #####
+
+# Accepter is the "other side" of the peering.
+resource "aws_ec2_transit_gateway_peering_attachment_accepter" "peer" {
+  provider = aws.peer
+
+  transit_gateway_attachment_id = aws_ec2_transit_gateway_peering_attachment.this.id
+  tags                          = var.tags
+}
+
+# One route table per TGW per peering, otherwise it fails with "tgw-attach-1 is already associated to a route table".
+resource "aws_ec2_transit_gateway_route_table_association" "peer" {
+  provider = aws.peer
+
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_peering_attachment_accepter.peer.transit_gateway_attachment_id
+  transit_gateway_route_table_id = var.peer_tgw_route_table.id
+}
+
+# Determine the peer's region by looking at its provider.
+data "aws_region" "peer_region" {
+  provider = aws.peer
+}
+
+# Determine the peer's AWS Account by looking at its provider.
+data "aws_caller_identity" "peer" {
+  provider = aws.peer
+}

--- a/modules/transit_gateway_peering/outputs.tf
+++ b/modules/transit_gateway_peering/outputs.tf
@@ -1,0 +1,19 @@
+output "peering_attachment" {
+  description = "The TGW Peering Attachment object, created under the provider `aws`."
+  value       = aws_ec2_transit_gateway_peering_attachment.this
+}
+
+output "peering_attachment_accepter" {
+  description = "The Accepter object, created under the provider `aws.peer`."
+  value       = aws_ec2_transit_gateway_peering_attachment_accepter.peer
+}
+
+output "local_route_table" {
+  description = "The route table associated to the TGW Peering Attachment, owned by the provider `aws`."
+  value       = var.local_tgw_route_table
+}
+
+output "peer_route_table" {
+  description = "The route table associated to the TGW Peering Attachment, owned by the provider `aws.peer`."
+  value       = var.peer_tgw_route_table
+}

--- a/modules/transit_gateway_peering/variables.tf
+++ b/modules/transit_gateway_peering/variables.tf
@@ -1,0 +1,37 @@
+variable "local_tgw_route_table" {
+  description = <<-EOF
+  Local TGW's pre-existing route table which should handle the traffic coming from the peered TGW (also called a route table association). An object with two attributes, the `id` of the local route table and the `transit_gateway_id` of the local TGW:
+  ```
+  transit_gateway_route_table = {
+    id                 = "tgw-rtb-1234"
+    transit_gateway_id = "tgw-1234"
+  }
+  ```
+  EOF
+  type = object({
+    id                 = string
+    transit_gateway_id = string
+  })
+}
+
+variable "peer_tgw_route_table" {
+  description = <<-EOF
+  Analog to the `local_tgw_route_table` but on the remote end of the peering.
+  EOF
+  type = object({
+    id                 = string
+    transit_gateway_id = string
+  })
+}
+
+variable "local_attachment_tags" {
+  description = "AWS tags to assign to the Attachment object. The tags are only visible in the UI when logged on the local account, but not on the remote peer account. Example: `{ Name = \"my-name\" }`"
+  default     = {}
+  type        = map(string)
+}
+
+variable "tags" {
+  description = "AWS tags to assign to all the created objects. Example: `{ Team = \"my-team\" }`"
+  default     = {}
+  type        = map(string)
+}

--- a/modules/transit_gateway_peering/versions.tf
+++ b/modules/transit_gateway_peering/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.15, < 2.0"
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 3.10"
+      configuration_aliases = [aws, aws.peer]
+    }
+  }
+}


### PR DESCRIPTION
Initial version of the module `transit_gateway_peering`, does not
handle routes.