### PR TITLE
feat(transit_gateway_peering): add a new module `transit_gateway_peer…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.13.7
+          terraform_version: 0.15.3
 
       - name: terraform validate
         env:
@@ -52,6 +52,13 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           for dir in $(find modules examples -type d -not \( -name ".?*" \) -maxdepth 1 -mindepth 1);
           do
+            if [[ "$dir" == "modules/transit_gateway_peering" ]];
+            then
+              echo "Skipping directory: $dir"
+              echo "Terraform does not support validating a module which uses an aliased provider (module-specific; validating an entire configuration works fine)."
+              continue
+            fi
+
             echo "Processing directory: $dir"
             cd "$GITHUB_WORKSPACE/$dir"
             terraform init -backend=false

--- a/examples/transit_gateway_peering/example.tfvars
+++ b/examples/transit_gateway_peering/example.tfvars
@@ -1,0 +1,2 @@
+region        = "eu-west-3"
+remote_region = "eu-north-1"

--- a/examples/transit_gateway_peering/main.tf
+++ b/examples/transit_gateway_peering/main.tf
@@ -1,0 +1,58 @@
+### Local Region (eu-west-3) ###
+
+module "transit_gateway" {
+  source = "../../modules/transit_gateway"
+
+  name = "${var.prefix_name_tag}${var.region}-tgw-1"
+  asn  = 65001
+  route_tables = {
+    "from_security_vpc" = {
+      create = true
+      name   = "${var.prefix_name_tag}from-security"
+    }
+    "from_spoke_vpc" = {
+      create = true
+      name   = "${var.prefix_name_tag}from-spokes"
+    }
+  }
+}
+
+### Remote Region (eu-north-1) ###
+
+# To be able to interact at all with a different AWS region, we need to declare
+# an alternative provider to what is normally defined in versions.tf.
+provider "aws" {
+  alias  = "remote"
+  region = var.remote_region
+}
+
+module "transit_gateway_remote" {
+  source = "../../modules/transit_gateway"
+  providers = {
+    aws = aws.remote
+  }
+
+  name = "${var.prefix_name_tag}${var.remote_region}-tgw-2"
+  asn  = 65000
+  route_tables = {
+    "from_spoke_vpc" = {
+      create = true
+      name   = "${var.prefix_name_tag}from-spokes"
+    }
+  }
+}
+
+### Cross-Region ###
+
+module "transit_gateway_peering" {
+  source = "../../modules/transit_gateway_peering"
+  providers = {
+    aws        = aws
+    aws.remote = aws.remote
+  }
+
+  local_tgw_route_table  = module.transit_gateway.route_tables["from_spoke_vpc"]
+  remote_tgw_route_table = module.transit_gateway_remote.route_tables["from_spoke_vpc"]
+
+  local_attachment_tags = { Name = "${var.prefix_name_tag}peering-attach" }
+}

--- a/examples/transit_gateway_peering/routes.tf
+++ b/examples/transit_gateway_peering/routes.tf
@@ -1,0 +1,28 @@
+# Optional routes across the peering.
+# Currently AWS only supports static routes, and not propagations, across a peering.
+#
+# As an example, assume:
+#   - the local region has a VPC named "security"
+#   - the remote region has a VPC named "spoke" (in a typical use case it can host a Panorama management appliance)
+
+resource "aws_ec2_transit_gateway_route" "from_remote_spoke_to_local_region" {
+  provider = aws.remote
+
+  destination_cidr_block         = "10.0.0.0/8"
+  transit_gateway_route_table_id = module.transit_gateway_remote.route_tables["from_spoke_vpc"].id
+  transit_gateway_attachment_id  = module.transit_gateway_peering.peering_attachment.id
+  blackhole                      = false
+
+  # Workaround: Explicit depends_on ensures that peering_attachment is already accepted when creating this route.
+  depends_on = [module.transit_gateway_peering]
+}
+
+resource "aws_ec2_transit_gateway_route" "from_local_security_to_remote_region" {
+  destination_cidr_block         = "10.244.0.0/16"
+  transit_gateway_route_table_id = module.transit_gateway.route_tables["from_security_vpc"].id
+  transit_gateway_attachment_id  = module.transit_gateway_peering.peering_attachment.id
+  blackhole                      = false
+
+  # Workaround: Explicit depends_on ensures that peering_attachment is already accepted when creating this route.
+  depends_on = [module.transit_gateway_peering]
+}

--- a/examples/transit_gateway_peering/variables.tf
+++ b/examples/transit_gateway_peering/variables.tf
@@ -1,0 +1,15 @@
+variable "region" {
+  description = "The AWS region where to create local resources."
+  type        = string
+}
+
+variable "remote_region" {
+  description = "The AWS region where to create remote resources."
+  type        = string
+}
+
+variable "prefix_name_tag" {
+  description = "Prefix for the AWS Name tags of all the created resources."
+  default     = ""
+  type        = string
+}

--- a/examples/transit_gateway_peering/versions.tf
+++ b/examples/transit_gateway_peering/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.15, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 3.50"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/modules/transit_gateway_peering/README.md
+++ b/modules/transit_gateway_peering/README.md
@@ -1,0 +1,76 @@
+# AWS Transit Gateway Peering
+
+## Usage
+
+This module creates both sides of a TGW Peering thus it needs two different AWS providers specified in the `providers` meta-argument.
+Without two providers it would be impossible to peer between two distinct AWS regions.
+
+The local side requires the provider entry named `aws`, the remote remote side requires the provider entry named `aws.remote`. The attachment
+is owned by the local side, and the attachment acceptor is owned by the remote side.
+
+```hcl2
+module transit_gateway_peering {
+  source = "../../modules/transit_gateway_peering"
+  providers = {
+    aws      = aws.east
+    aws.remote = aws.west
+  }
+
+  local_tgw_route_table   = module.transit_gateway_east.route_tables["traffic_from_west"]
+  remote_tgw_route_table  = module.transit_gateway_west.route_tables["traffic_from_east"]
+}
+
+provider "aws" {
+  alias  = "east"
+  region = "us-east-2"
+}
+
+provider "aws" {
+  alias  = "west"
+  region = "us-west-2"
+}
+```
+
+The static routes are currently not handled by this module.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15, < 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ec2_transit_gateway_peering_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment) | resource |
+| [aws_ec2_transit_gateway_peering_attachment_accepter.remote](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment_accepter) | resource |
+| [aws_ec2_transit_gateway_route_table_association.local](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
+| [aws_ec2_transit_gateway_route_table_association.remote](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
+| [aws_caller_identity.remote](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.remote_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_local_attachment_tags"></a> [local\_attachment\_tags](#input\_local\_attachment\_tags) | AWS tags to assign to the Attachment object. The tags are only visible in the UI when logged on the local account, but not when logged on the remote peer account. Example: `{ Name = "my-name" }` | `map(string)` | `{}` | no |
+| <a name="input_local_tgw_route_table"></a> [local\_tgw\_route\_table](#input\_local\_tgw\_route\_table) | Local TGW's pre-existing route table which should handle the traffic coming from the remote TGW. In other words a route table associated to the peering in the local region. An object with two attributes, the `id` of the local route table and the `transit_gateway_id` of the local TGW:<pre>transit_gateway_route_table = {<br>  id                 = "tgw-rtb-1234"<br>  transit_gateway_id = "tgw-1234"<br>}</pre> | <pre>object({<br>    id                 = string<br>    transit_gateway_id = string<br>  })</pre> | n/a | yes |
+| <a name="input_remote_tgw_route_table"></a> [remote\_tgw\_route\_table](#input\_remote\_tgw\_route\_table) | Analog to the `local_tgw_route_table` but on the remote end of the peering. | <pre>object({<br>    id                 = string<br>    transit_gateway_id = string<br>  })</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | AWS tags to assign to all the created objects. Example: `{ Team = "my-team" }` | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_local_route_table"></a> [local\_route\_table](#output\_local\_route\_table) | The route table associated to the TGW Peering Attachment, owned by the provider `aws`. |
+| <a name="output_peering_attachment"></a> [peering\_attachment](#output\_peering\_attachment) | The TGW Peering Attachment object, created under the provider `aws`. |
+| <a name="output_peering_attachment_accepter"></a> [peering\_attachment\_accepter](#output\_peering\_attachment\_accepter) | The Accepter object, created under the provider `aws.remote`. |
+| <a name="output_remote_route_table"></a> [remote\_route\_table](#output\_remote\_route\_table) | The route table associated to the TGW Peering Attachment, owned by the provider `aws.remote`. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/transit_gateway_peering/main.tf
+++ b/modules/transit_gateway_peering/main.tf
@@ -1,0 +1,59 @@
+# Why is the code split between module `transit_gateway` and `transit_gateway_peering`?
+#
+# With TGW peering, the module which creates an Attachment needs to see first *both* TGWs completed.
+# And then, Accepter needs to see the Attachment completed.
+# Hence Accepter cannot be created in the same module as its TGW, because the module first needs
+# to emit the TGW identifier and then wait for Attachment identifier to become usable.
+# Since both the Route Tables can be only associated after the Accepter finishes, the dependency
+# hassle is minimized by putting together Peering Attachment + Peering Accepter + Peering Route Tables
+# in the same module.
+# The downside of this choice is that the resulting module needs two AWS providers, not one.
+
+##### Request from the "local" region to the "remote" region #####
+
+resource "aws_ec2_transit_gateway_peering_attachment" "this" {
+  peer_account_id         = data.aws_caller_identity.remote.account_id
+  peer_region             = data.aws_region.remote_region.name
+  peer_transit_gateway_id = var.remote_tgw_route_table.transit_gateway_id
+  transit_gateway_id      = var.local_tgw_route_table.transit_gateway_id
+  tags                    = merge(var.tags, var.local_attachment_tags)
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "local" {
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_peering_attachment.this.id
+  transit_gateway_route_table_id = var.local_tgw_route_table.id
+
+  # Workaround for apply error "IncorrectState: tgw-attach-1 is in invalid state" (i.e. unaccepted).
+  depends_on = [aws_ec2_transit_gateway_peering_attachment_accepter.remote]
+}
+
+# The aws_ec2_transit_gateway_route_table_propagation here wouldn't be supported by AWS, failing with:
+# "You cannot propagate a peering attachment to a Transit Gateway Route Table".
+
+##### Accept from the "remote" region to the "local" region #####
+
+# Accepter is the "other side" of the peering.
+resource "aws_ec2_transit_gateway_peering_attachment_accepter" "remote" {
+  provider = aws.remote
+
+  transit_gateway_attachment_id = aws_ec2_transit_gateway_peering_attachment.this.id
+  tags                          = var.tags
+}
+
+# One route table per TGW per peering, otherwise it fails with "tgw-attach-1 is already associated to a route table".
+resource "aws_ec2_transit_gateway_route_table_association" "remote" {
+  provider = aws.remote
+
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_peering_attachment_accepter.remote.transit_gateway_attachment_id
+  transit_gateway_route_table_id = var.remote_tgw_route_table.id
+}
+
+# Determine the peer's region by looking at its provider.
+data "aws_region" "remote_region" {
+  provider = aws.remote
+}
+
+# Determine the peer's AWS Account by looking at its provider.
+data "aws_caller_identity" "remote" {
+  provider = aws.remote
+}

--- a/modules/transit_gateway_peering/outputs.tf
+++ b/modules/transit_gateway_peering/outputs.tf
@@ -1,0 +1,19 @@
+output "peering_attachment" {
+  description = "The TGW Peering Attachment object, created under the provider `aws`."
+  value       = aws_ec2_transit_gateway_peering_attachment.this
+}
+
+output "peering_attachment_accepter" {
+  description = "The Accepter object, created under the provider `aws.remote`."
+  value       = aws_ec2_transit_gateway_peering_attachment_accepter.remote
+}
+
+output "local_route_table" {
+  description = "The route table associated to the TGW Peering Attachment, owned by the provider `aws`."
+  value       = var.local_tgw_route_table
+}
+
+output "remote_route_table" {
+  description = "The route table associated to the TGW Peering Attachment, owned by the provider `aws.remote`."
+  value       = var.remote_tgw_route_table
+}

--- a/modules/transit_gateway_peering/variables.tf
+++ b/modules/transit_gateway_peering/variables.tf
@@ -1,0 +1,37 @@
+variable "local_tgw_route_table" {
+  description = <<-EOF
+  Local TGW's pre-existing route table which should handle the traffic coming from the remote TGW. In other words a route table associated to the peering in the local region. An object with two attributes, the `id` of the local route table and the `transit_gateway_id` of the local TGW:
+  ```
+  transit_gateway_route_table = {
+    id                 = "tgw-rtb-1234"
+    transit_gateway_id = "tgw-1234"
+  }
+  ```
+  EOF
+  type = object({
+    id                 = string
+    transit_gateway_id = string
+  })
+}
+
+variable "remote_tgw_route_table" {
+  description = <<-EOF
+  Analog to the `local_tgw_route_table` but on the remote end of the peering.
+  EOF
+  type = object({
+    id                 = string
+    transit_gateway_id = string
+  })
+}
+
+variable "local_attachment_tags" {
+  description = "AWS tags to assign to the Attachment object. The tags are only visible in the UI when logged on the local account, but not when logged on the remote peer account. Example: `{ Name = \"my-name\" }`"
+  default     = {}
+  type        = map(string)
+}
+
+variable "tags" {
+  description = "AWS tags to assign to all the created objects. Example: `{ Team = \"my-team\" }`"
+  default     = {}
+  type        = map(string)
+}

--- a/modules/transit_gateway_peering/versions.tf
+++ b/modules/transit_gateway_peering/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.15, < 2.0" # 0.15 is the lowest version supporting `configuration_aliases`.
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 3.10"
+      configuration_aliases = [aws, aws.remote]
+    }
+  }
+}


### PR DESCRIPTION
…ing`

Initial version of the module `transit_gateway_peering`, does not
handle routes.

Bump terraform version used for CI `terraform validate` to
0.15.3 to avoid error on aliased provider: `[aws, aws.remote]`

Exclude module from `terraform validate`, because Terraform is unable to
validate it from within. The validation of the module is achieved
recursively through the validation of `example/transit_gateway_peering`.

commit-id:7350b872