### PR TITLE
Fix: typo in gwlb endpoint set outputs

### DIFF
--- a/modules/gwlb_endpoint_set/README.md
+++ b/modules/gwlb_endpoint_set/README.md
@@ -39,6 +39,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_enpoints"></a> [enpoints](#output\_enpoints) | Map of the created endpoints. The keys are the same as the keys of the input `subnets`. |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | Map of the created endpoints. The keys are the same as the keys of the input `subnets`. |
 | <a name="output_next_hop_set"></a> [next\_hop\_set](#output\_next\_hop\_set) | The Next Hop Set object, useful as an input to the `vpc_route` module. The intention would<br>be to route traffic from subnets to endpoints while preventing cross-AZ traffic (so<br>that a subnet in AZ-a only routes to an endpoint in AZ-a). Example:<pre>next_hop_set = {<br>  ids = {<br>    "us-east-1a" = "gwlbe-0ddf598f93a8ea8ae"<br>    "us-east-1b" = "gwlbe-0862c4b707b012111"<br>  }<br>  id   = null<br>  type = "vpc_endpoint"<br>}</pre> |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/gwlb_endpoint_set/outputs.tf
+++ b/modules/gwlb_endpoint_set/outputs.tf
@@ -22,7 +22,7 @@ output "next_hop_set" {
   }
 }
 
-output "enpoints" {
+output "endpoints" {
   description = "Map of the created endpoints. The keys are the same as the keys of the input `subnets`."
   value       = aws_vpc_endpoint.this
 }


### PR DESCRIPTION
## Description

Fix typo in output from gwlb endpoint set module. 

## Motivation and Context

We found typo when creating endpoint list for output.

## How Has This Been Tested?

I deployed stack to AWS with set outputs to endpoints.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
