### PR TITLE
feat(vmseries): Add output with created public IPs

### DIFF
--- a/examples/tgw_inbound_combined_with_gwlb/README.md
+++ b/examples/tgw_inbound_combined_with_gwlb/README.md
@@ -105,4 +105,5 @@ In a nutshell it means:
 | <a name="output_app1_inspected_dns_name"></a> [app1\_inspected\_dns\_name](#output\_app1\_inspected\_dns\_name) | The DNS name that you can use to SSH into a testbox. Use username `bitnami` and the private key matching the public key configured with the input `ssh_public_key_file_path`. |
 | <a name="output_app1_inspected_public_ip"></a> [app1\_inspected\_public\_ip](#output\_app1\_inspected\_public\_ip) | The IP address behind the `app1_inspected_dns_name`. |
 | <a name="output_security_gwlb_service_name"></a> [security\_gwlb\_service\_name](#output\_security\_gwlb\_service\_name) | The AWS Service Name of the created GWLB, which is suitable to use for subsequent VPC Endpoints. |
+| <a name="output_vmseries_public_ips"></a> [vmseries\_public\_ips](#output\_vmseries\_public\_ips) | Map of public IPs created within `vmseries` module instances. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/tgw_inbound_combined_with_gwlb/outputs.tf
+++ b/examples/tgw_inbound_combined_with_gwlb/outputs.tf
@@ -5,6 +5,11 @@ output "security_gwlb_service_name" {
   value       = module.security_gwlb.endpoint_service.service_name
 }
 
+output "vmseries_public_ips" {
+  description = "Map of public IPs created within `vmseries` module instances."
+  value       = { for k, v in module.vmseries : k => v.public_ips }
+}
+
 ##### App1 VPC #####
 
 output "app1_inspected_dns_name" {

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -64,4 +64,5 @@ No modules.
 |------|-------------|
 | <a name="output_instance"></a> [instance](#output\_instance) | n/a |
 | <a name="output_interfaces"></a> [interfaces](#output\_interfaces) | Map of VM-Series network interfaces. The entries are `aws_network_interface` objects. |
+| <a name="output_public_ips"></a> [public\_ips](#output\_public\_ips) | Map of public IPs created within the module. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vmseries/outputs.tf
+++ b/modules/vmseries/outputs.tf
@@ -6,3 +6,8 @@ output "interfaces" {
   description = "Map of VM-Series network interfaces. The entries are `aws_network_interface` objects."
   value       = aws_network_interface.this
 }
+
+output "public_ips" {
+  description = "Map of public IPs created within the module."
+  value       = { for k, v in aws_eip.this : k => v.public_ip }
+}


### PR DESCRIPTION
## Description

Add an output with public IPs created within a module.

## Motivation and Context

The address may be further used as inputs for other resources.

## How Has This Been Tested?

Deploy example using terraform 1.1.4.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
