### PR TITLE
fix(bootstrap): Add bootstrap plugin variable

### DIFF
--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -37,16 +37,14 @@ provider "aws" {
 
 module "panos-bootstrap" {
   source  = "PaloAltoNetworks/panos-bootstrap/aws"
-  version = "1.0.0"
 
-  bootstrap_region      = var.bootstrap_region
-
-  hostname         = "my-firewall"
-  panorama-server  = "panorama1.example.org"
-  panorama-server2 = "panorama2.example.org"
-  tplname          = "My Firewall Template"
-  dgname           = "My Firewalls"
-  vm-auth-key      = "supersecretauthkey"
+  hostname           = "my-firewall"
+  panorama-server    = "panorama1.example.org"
+  panorama-server2   = "panorama2.example.org"
+  tplname            = "My Firewall Template"
+  dgname             = "My Firewalls"
+  vm-auth-key        = "supersecretauthkey"
+  plugin-op-commands = "aws-gwlb-inspect:enable"
 }
 ```
 

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -36,7 +36,7 @@ provider "aws" {
 }
 
 module "panos-bootstrap" {
-  source  = "PaloAltoNetworks/panos-bootstrap/aws"
+  source = "../../modules/bootstrap"
 
   hostname           = "my-firewall"
   panorama-server    = "panorama1.example.org"

--- a/modules/bootstrap/init-cfg.txt.tmpl
+++ b/modules/bootstrap/init-cfg.txt.tmpl
@@ -5,6 +5,7 @@ panorama-server-2=${panorama-server2}
 tplname=${tplname}
 dgname=${dgname}
 vm-auth-key=${vm-auth-key}
+plugin-op-commands=${plugin-op-commands}
 op-command-modes=${op-command-modes}
 dhcp-send-hostname=yes
 dhcp-send-client-id=yes

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -24,15 +24,16 @@ resource "aws_s3_bucket_object" "init_cfg" {
   key    = "config/init-cfg.txt"
   content = templatefile("${path.module}/init-cfg.txt.tmpl",
     {
-      "hostname"         = var.hostname,
-      "panorama-server"  = var.panorama-server,
-      "panorama-server2" = var.panorama-server2,
-      "tplname"          = var.tplname,
-      "dgname"           = var.dgname,
-      "dns-primary"      = var.dns-primary,
-      "dns-secondary"    = var.dns-secondary,
-      "vm-auth-key"      = var.vm-auth-key,
-      "op-command-modes" = var.op-command-modes
+      "hostname"           = var.hostname,
+      "panorama-server"    = var.panorama-server,
+      "panorama-server2"   = var.panorama-server2,
+      "tplname"            = var.tplname,
+      "dgname"             = var.dgname,
+      "dns-primary"        = var.dns-primary,
+      "dns-secondary"      = var.dns-secondary,
+      "vm-auth-key"        = var.vm-auth-key,
+      "op-command-modes"   = var.op-command-modes,
+      "plugin-op-commands" = var.plugin-op-commands
     }
   )
 }

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -94,3 +94,9 @@ variable "op-command-modes" { # tflint-ignore: terraform_naming_convention # TOD
   default     = ""
   type        = string
 }
+
+variable "plugin-op-commands" { # tflint-ignore: terraform_naming_convention # TODO rename to snake_case
+  description = "Set plugin-op-commands."
+  default     = ""
+  type        = string
+}


### PR DESCRIPTION
## Description

Add plugin-op-commands variable in template file.

## Motivation and Context

Without plugin-op-commands in template file - it is not possible to associate gwlbe with sub-interface or enable overlay routing.

## How Has This Been Tested?

Tested by pushing new variable to green deployment and inspect the ```show system bootstrap status``` command.


## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue) - Issue #176 


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
