### PR TITLE
fix(module/vmseries): default kms key is referenced by alias

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           directory: .
           framework: terraform 
+          compact: true
           soft_fail: true
           quiet: true # display only failed checks
           

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ terraform.tfvars.json
 *.auto.tfvars
 *.auto.tfvars.json
 
+.terraform.lock.hcl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,7 @@ repos:
     hooks:
     - id: checkov
       verbose: true
-      args: [--soft-fail]
+      args: 
+        - '--compact'
+        - '--quiet'
+        - '--soft-fail'

--- a/examples/standalone_vmseries_with_userdata_bootstrap/README.md
+++ b/examples/standalone_vmseries_with_userdata_bootstrap/README.md
@@ -43,6 +43,10 @@ terraform destroy
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.74 |
 
+## Providers
+
+No providers.
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/tgw_inbound_combined_with_gwlb/README.md
+++ b/examples/tgw_inbound_combined_with_gwlb/README.md
@@ -24,6 +24,12 @@ In a nutshell it means:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.74 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | = 3.74 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/vmseries_combined_with_gwlb_natgw/README.md
+++ b/examples/vmseries_combined_with_gwlb_natgw/README.md
@@ -1,0 +1,88 @@
+# Palo Alto Networks VM-Series NGFW Module Example for AWS Cloud
+
+A Terraform module example allowing to deploy two instances of the Palo Alto Networks VM-Series NGFW combined with a [Gateway Load Balancer](https://aws.amazon.com/elasticloadbalancing/gateway-load-balancer/#:~:text=Gateway%20Load%20Balancer%20helps%20you,or%20down%2C%20based%20on%20demand.) and a [NAT Gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) in AWS Cloud.
+
+**NOTE:**
+The Security Group attached to the Management interface uses an inbound rule allowing traffic to port `22` and `443` from `0.0.0.0/0`, which means that SSH and HTTP access to the NFGW is possible from all over the Internet. You should update the Security Group rules and limit access to the Management interface, for example - to only the public IP address from which you will connect to VM-Series.
+
+## Usage
+
+Create a `terraform.tfvars` file and copy the content of `example.tfvars` into it, adjust if needed.
+
+Then execute:
+
+```sh
+terraform init
+terraform apply
+terraform output -json mgmt_eip
+```
+
+Connect through SSH to the VM-Series Management interface IP address using the SSH key you provided as the  `ssh_key_name` parameter in your `terraform.tfvars` file:
+
+```sh
+ssh <username>@<mgmt_eip> -i <path_to_your_private_ssh_key>
+```
+
+## Cleanup
+
+To delete all the resources created by the previous `apply` attempts, execute:
+
+```sh
+terraform destroy
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.74 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_gwlbe_outbound"></a> [gwlbe\_outbound](#module\_gwlbe\_outbound) | ../../modules/gwlb_endpoint_set | n/a |
+| <a name="module_natgw_set"></a> [natgw\_set](#module\_natgw\_set) | ../../modules/nat_gateway_set | n/a |
+| <a name="module_security_gwlb"></a> [security\_gwlb](#module\_security\_gwlb) | ../../modules/gwlb | n/a |
+| <a name="module_security_subnet_sets"></a> [security\_subnet\_sets](#module\_security\_subnet\_sets) | ../../modules/subnet_set | n/a |
+| <a name="module_security_vpc"></a> [security\_vpc](#module\_security\_vpc) | ../../modules/vpc | n/a |
+| <a name="module_security_vpc_routes"></a> [security\_vpc\_routes](#module\_security\_vpc\_routes) | ../../modules/vpc_route | n/a |
+| <a name="module_vmseries"></a> [vmseries](#module\_vmseries) | ../../modules/vmseries | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bootstrap_options"></a> [bootstrap\_options](#input\_bootstrap\_options) | n/a | `any` | n/a | yes |
+| <a name="input_create_ssh_key"></a> [create\_ssh\_key](#input\_create\_ssh\_key) | n/a | `any` | n/a | yes |
+| <a name="input_firewalls"></a> [firewalls](#input\_firewalls) | n/a | `any` | n/a | yes |
+| <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | n/a | `any` | n/a | yes |
+| <a name="input_gwlb_endpoint_set_outbound_name"></a> [gwlb\_endpoint\_set\_outbound\_name](#input\_gwlb\_endpoint\_set\_outbound\_name) | n/a | `any` | n/a | yes |
+| <a name="input_gwlb_name"></a> [gwlb\_name](#input\_gwlb\_name) | n/a | `any` | n/a | yes |
+| <a name="input_nat_gateway_name"></a> [nat\_gateway\_name](#input\_nat\_gateway\_name) | n/a | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | ## General | `any` | n/a | yes |
+| <a name="input_security_vpc_cidr"></a> [security\_vpc\_cidr](#input\_security\_vpc\_cidr) | n/a | `any` | n/a | yes |
+| <a name="input_security_vpc_name"></a> [security\_vpc\_name](#input\_security\_vpc\_name) | n/a | `any` | n/a | yes |
+| <a name="input_security_vpc_routes_outbound_destin_cidrs"></a> [security\_vpc\_routes\_outbound\_destin\_cidrs](#input\_security\_vpc\_routes\_outbound\_destin\_cidrs) | n/a | `any` | n/a | yes |
+| <a name="input_security_vpc_routes_outbound_source_cidrs"></a> [security\_vpc\_routes\_outbound\_source\_cidrs](#input\_security\_vpc\_routes\_outbound\_source\_cidrs) | n/a | `any` | n/a | yes |
+| <a name="input_security_vpc_security_groups"></a> [security\_vpc\_security\_groups](#input\_security\_vpc\_security\_groups) | n/a | `any` | n/a | yes |
+| <a name="input_security_vpc_subnets"></a> [security\_vpc\_subnets](#input\_security\_vpc\_subnets) | n/a | `any` | n/a | yes |
+| <a name="input_ssh_key_name"></a> [ssh\_key\_name](#input\_ssh\_key\_name) | n/a | `any` | n/a | yes |
+| <a name="input_vmseries_version"></a> [vmseries\_version](#input\_vmseries\_version) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_public_ips"></a> [public\_ips](#output\_public\_ips) | Map of public IPs created within the module. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vmseries_combined_with_gwlb_natgw/example.tfvars
+++ b/examples/vmseries_combined_with_gwlb_natgw/example.tfvars
@@ -1,0 +1,103 @@
+# General
+region = "us-east-1"
+global_tags = {
+  ManagedBy   = "Terraform"
+  Application = "Palo Alto Networks VM-Series NGFW"
+}
+
+# Security VPC
+security_vpc_name = "example-security-vpc"
+security_vpc_cidr = "10.100.0.0/16"
+
+# Security groups
+security_vpc_security_groups = {
+  vmseries_mgmt = {
+    name = "vmseries_mgmt"
+    rules = {
+      all_outbound = {
+        description = "Permit All traffic outbound"
+        type        = "egress", from_port = "0", to_port = "0", protocol = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+      }
+      https = {
+        description = "Permit HTTPS"
+        type        = "ingress", from_port = "443", to_port = "443", protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"] # TODO: update here
+      }
+      ssh = {
+        description = "Permit SSH"
+        type        = "ingress", from_port = "22", to_port = "22", protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"] # TODO: update here
+      }
+    }
+  }
+  vmseries_data = {
+    name = "vmseries_data"
+    rules = {
+      geneve = {
+        description = "Permit GENEVE to GWLB subnets"
+        type        = "ingress", from_port = "6081", to_port = "6081", protocol = "udp"
+        cidr_blocks = ["10.100.4.0/24", "10.100.68.0/24"]
+      }
+      health_probe = {
+        description = "Permit Port 80 Health Probe to GWLB subnets"
+        type        = "ingress", from_port = "80", to_port = "80", protocol = "tcp"
+        cidr_blocks = ["10.100.4.0/24", "10.100.68.0/24"]
+      }
+    }
+  }
+  vmseries_untrust = {
+    name = "vmseries_untrust"
+    rules = {
+      all_outbound = {
+        description = "Permit All traffic outbound"
+        type        = "egress", from_port = "0", to_port = "0", protocol = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+      }
+    }
+  }
+}
+
+# Security VPC Subnets
+security_vpc_subnets = {
+  # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
+  "10.100.0.0/24"  = { az = "us-east-1a", set = "mgmt" }
+  "10.100.64.0/24" = { az = "us-east-1b", set = "mgmt" }
+  "10.100.1.0/24"  = { az = "us-east-1a", set = "data" }
+  "10.100.65.0/24" = { az = "us-east-1b", set = "data" }
+  "10.100.2.0/24"  = { az = "us-east-1a", set = "untrust" }
+  "10.100.66.0/24" = { az = "us-east-1b", set = "untrust" }
+  "10.100.3.0/24"  = { az = "us-east-1a", set = "gwlbe_outbound" }
+  "10.100.67.0/24" = { az = "us-east-1b", set = "gwlbe_outbound" }
+  "10.100.4.0/24"  = { az = "us-east-1a", set = "gwlb" }
+  "10.100.68.0/24" = { az = "us-east-1b", set = "gwlb" }
+  "10.100.5.0/24"  = { az = "us-east-1a", set = "natgw" }
+  "10.100.69.0/24" = { az = "us-east-1b", set = "natgw" }
+}
+
+# Gateway Load Balancer
+gwlb_name                       = "example-security-gwlb"
+gwlb_endpoint_set_outbound_name = "outbound-gwlb-endpoint"
+
+### NAT gateway
+nat_gateway_name = "example-natgw"
+
+# VM-Series
+vmseries_version = "10.1.3"
+create_ssh_key   = false
+ssh_key_name     = "example-ssh-key"
+firewalls = {
+  vmseries01 = { az = "us-east-1a" }
+  vmseries02 = { az = "us-east-1b" }
+}
+
+bootstrap_options = "mgmt-interface-swap=enable;plugin-op-commands=aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable;type=dhcp-client"
+
+# Security VPC routes ###
+security_vpc_routes_outbound_source_cidrs = [ # outbound traffic return after inspection
+  "10.0.0.0/8",
+]
+
+security_vpc_routes_outbound_destin_cidrs = [ # outbound traffic incoming for inspection from TGW
+  "0.0.0.0/0",
+]

--- a/examples/vmseries_combined_with_gwlb_natgw/main.tf
+++ b/examples/vmseries_combined_with_gwlb_natgw/main.tf
@@ -1,0 +1,141 @@
+module "security_vpc" {
+  source = "../../modules/vpc"
+
+  name                    = var.security_vpc_name
+  cidr_block              = var.security_vpc_cidr
+  security_groups         = var.security_vpc_security_groups
+  create_internet_gateway = true
+  enable_dns_hostnames    = true
+  enable_dns_support      = true
+  instance_tenancy        = "default"
+}
+
+module "security_subnet_sets" {
+  # The "set" here means we will repeat in each AZ an identical/similar subnet.
+  # The notion of "set" is used a lot here, it extends to routes, routes' next hops,
+  # gwlb endpoints and any other resources which would be a single point of failure when placed
+  # in a single AZ.
+  for_each = toset(distinct([for _, v in var.security_vpc_subnets : v.set]))
+  source   = "../../modules/subnet_set"
+
+  name                = each.key
+  vpc_id              = module.security_vpc.id
+  has_secondary_cidrs = module.security_vpc.has_secondary_cidrs
+  cidrs               = { for k, v in var.security_vpc_subnets : k => v if v.set == each.key }
+}
+
+module "natgw_set" {
+  # This also a "set" and it means the same thing: we will repeat a nat gateway for each subnet (of the subnet_set).
+  source = "../../modules/nat_gateway_set"
+
+  subnets = module.security_subnet_sets["natgw"].subnets
+}
+
+# Gateway Load Balancer
+module "security_gwlb" {
+  source = "../../modules/gwlb"
+
+  name    = var.gwlb_name
+  vpc_id  = module.security_subnet_sets["gwlb"].vpc_id
+  subnets = module.security_subnet_sets["gwlb"].subnets
+
+  target_instances = { for k, v in module.vmseries : k => { id = v.instance.id } }
+}
+
+# Gateway Load Balancer Endpoints
+module "gwlbe_outbound" {
+  source = "../../modules/gwlb_endpoint_set"
+
+  name              = var.gwlb_endpoint_set_outbound_name
+  gwlb_service_name = module.security_gwlb.endpoint_service.service_name
+  vpc_id            = module.security_subnet_sets["gwlbe_outbound"].vpc_id
+  subnets           = module.security_subnet_sets["gwlbe_outbound"].subnets
+}
+
+# VM-Series
+module "vmseries" {
+  source = "../../modules/vmseries"
+
+  for_each = var.firewalls
+
+  name              = each.key
+  tags              = var.global_tags
+  ssh_key_name      = var.ssh_key_name
+  bootstrap_options = var.bootstrap_options
+  vmseries_version  = var.vmseries_version
+
+  interfaces = {
+    data = {
+      device_index       = 0
+      security_group_ids = [module.security_vpc.security_group_ids["vmseries_data"]]
+      source_dest_check  = false
+      subnet_id          = module.security_subnet_sets["data"].subnets[each.value.az].id
+      create_public_ip   = false
+    }
+    mgmt = {
+      device_index       = 1
+      security_group_ids = [module.security_vpc.security_group_ids["vmseries_mgmt"]]
+      source_dest_check  = true
+      subnet_id          = module.security_subnet_sets["mgmt"].subnets[each.value.az].id
+      create_public_ip   = true
+    }
+    untrust = {
+      device_index       = 2
+      security_group_ids = [module.security_vpc.security_group_ids["vmseries_untrust"]]
+      source_dest_check  = false
+      subnet_id          = module.security_subnet_sets["untrust"].subnets[each.value.az].id
+      create_public_ip   = true
+    }
+  }
+}
+
+locals {
+  security_vpc_routes = concat(
+    [for cidr in var.security_vpc_routes_outbound_destin_cidrs :
+      {
+        subnet_key   = "untrust"
+        next_hop_set = module.natgw_set.next_hop_set
+        to_cidr      = cidr
+      }
+    ],
+    [for cidr in var.security_vpc_routes_outbound_destin_cidrs :
+      {
+        subnet_key   = "natgw"
+        next_hop_set = module.security_vpc.igw_as_next_hop_set
+        to_cidr      = cidr
+      }
+    ],
+    [for cidr in var.security_vpc_routes_outbound_destin_cidrs :
+      {
+        subnet_key   = "mgmt"
+        next_hop_set = module.security_vpc.igw_as_next_hop_set
+        to_cidr      = cidr
+      }
+    ],
+    [for cidr in var.security_vpc_routes_outbound_destin_cidrs :
+      {
+        subnet_key   = "gwlbe_outbound"
+        next_hop_set = module.natgw_set.next_hop_set
+        to_cidr      = cidr
+      }
+    ],
+
+    [for cidr in var.security_vpc_routes_outbound_source_cidrs :
+      {
+        subnet_key   = "natgw"
+        next_hop_set = module.gwlbe_outbound.next_hop_set
+        to_cidr      = cidr
+      }
+    ],
+  )
+}
+
+# Security VPC Routes
+module "security_vpc_routes" {
+  for_each = { for route in local.security_vpc_routes : "${route.subnet_key}_${route.to_cidr}" => route }
+  source   = "../../modules/vpc_route"
+
+  route_table_ids = module.security_subnet_sets[each.value.subnet_key].unique_route_table_ids
+  to_cidr         = each.value.to_cidr
+  next_hop_set    = each.value.next_hop_set
+}

--- a/examples/vmseries_combined_with_gwlb_natgw/outputs.tf
+++ b/examples/vmseries_combined_with_gwlb_natgw/outputs.tf
@@ -1,0 +1,4 @@
+output "public_ips" {
+  description = "Map of public IPs created within the module."
+  value       = { for k, v in module.vmseries : k => v.public_ips }
+}

--- a/examples/vmseries_combined_with_gwlb_natgw/variables.tf
+++ b/examples/vmseries_combined_with_gwlb_natgw/variables.tf
@@ -1,0 +1,17 @@
+### General
+variable "region" {}
+variable "global_tags" {}
+variable "security_vpc_name" {}
+variable "security_vpc_cidr" {}
+variable "security_vpc_security_groups" {}
+variable "gwlb_name" {}
+variable "security_vpc_routes_outbound_source_cidrs" {}
+variable "security_vpc_routes_outbound_destin_cidrs" {}
+variable "gwlb_endpoint_set_outbound_name" {}
+variable "security_vpc_subnets" {}
+variable "create_ssh_key" {}
+variable "ssh_key_name" {}
+variable "nat_gateway_name" {}
+variable "firewalls" {}
+variable "bootstrap_options" {}
+variable "vmseries_version" {}

--- a/examples/vmseries_combined_with_gwlb_natgw/versions.tf
+++ b/examples/vmseries_combined_with_gwlb_natgw/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.13.7, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.74"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -66,58 +66,73 @@ variables and associated values.
 8. Validate the plan using the `terraform plan` command.
 9. Apply the plan using the `terraform apply` command. 
 
-## Utilization
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
 
-The module output will provide values for the `bucket_id` and 
-`instance_profile_name`.  The `bucket_id` value can then be used in a
-`aws_instance` resource to instantiate a VM-Series instance.  It is used in
-the `user-data` parameter.  The `instance_profile_name` value is used in the
-`iam_instance_profile` parameter.  Both are neeeded to define the location of
-the S3 bootstrap bucket and the permissions needed to access it.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 
-```terraform
-resource "aws_instance" "fw" {
-  ami           = "${data.aws_ami.fw_ami.id}"
-  instance_type = "${var.fw_instance_type}"
-  key_name      = "${var.ssh_key_name}"
+## Providers
 
-  disable_api_termination              = false
-  instance_initiated_shutdown_behavior = "stop"
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~>3.0 |
 
-  ebs_optimized = true
+## Modules
 
-  root_block_device {
-    volume_type           = "gp2"
-    delete_on_termination = true
-  }
+No modules.
 
-  network_interface {
-    device_index         = 0
-    network_interface_id = "${aws_network_interface.fw_mgmt.id}"
-  }
+## Resources
 
-  network_interface {
-    device_index         = 1
-    network_interface_id = "${aws_network_interface.fw_eth1.id}"
-  }
+| Name | Type |
+|------|------|
+| [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.bootstrap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_object.bootstrap_dirs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_object.bootstrap_files](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_object.init_cfg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [random_id.bucket_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
-  network_interface {
-    device_index         = 2
-    network_interface_id = "${aws_network_interface.fw_eth2.id}"
-  }
+## Inputs
 
-  network_interface {
-    device_index         = 3
-    network_interface_id = "${aws_network_interface.fw_eth3.id}"
-  }
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bootstrap_directories"></a> [bootstrap\_directories](#input\_bootstrap\_directories) | List of subdirectories to be created inside the bucket (whether or not they exist locally inside the `source_root_directory`). A hardcoded pan-os requirement. | `list(string)` | <pre>[<br>  "config/",<br>  "content/",<br>  "software/",<br>  "license/",<br>  "plugins/"<br>]</pre> | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of a bucket to reuse or create (depending on `create_bucket` value). In the latter case - if empty, the name will be auto-generated. | `string` | `""` | no |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | If true, a new bucket will be created. When false, name of existing bucket to use has to be provided in `bucket_name` variable. | `bool` | `true` | no |
+| <a name="input_dgname"></a> [dgname](#input\_dgname) | The Panorama device group name. | `string` | `""` | no |
+| <a name="input_dns-primary"></a> [dns-primary](#input\_dns-primary) | The IP address of the primary DNS server. | `string` | `""` | no |
+| <a name="input_dns-secondary"></a> [dns-secondary](#input\_dns-secondary) | The IP address of the secondary DNS server. | `string` | `""` | no |
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Set to false to prevent Terraform from destroying a bucket with unknown objects or locked objects. | `bool` | `true` | no |
+| <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Map of arbitrary tags to apply to all resources. | `map(any)` | `{}` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | The hostname of the VM-series instance. | `string` | `""` | no |
+| <a name="input_iam_instance_profile_name"></a> [iam\_instance\_profile\_name](#input\_iam\_instance\_profile\_name) | Name of the instance profile to create. If empty, name will be auto-generated. | `string` | `""` | no |
+| <a name="input_op-command-modes"></a> [op-command-modes](#input\_op-command-modes) | Set jumbo-frame and/or mgmt-interface-swap. | `string` | `""` | no |
+| <a name="input_panorama-server"></a> [panorama-server](#input\_panorama-server) | The FQDN or IP address of the primary Panorama server. | `string` | `""` | no |
+| <a name="input_panorama-server2"></a> [panorama-server2](#input\_panorama-server2) | The FQDN or IP address of the secondary Panorama server. | `string` | `""` | no |
+| <a name="input_plugin-op-commands"></a> [plugin-op-commands](#input\_plugin-op-commands) | Set plugin-op-commands. | `string` | `""` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix to use for bucket name, IAM role name, and IAM role policy name. It is allowed to use dash "-" as the last character. | `string` | `"bootstrap-"` | no |
+| <a name="input_source_root_directory"></a> [source\_root\_directory](#input\_source\_root\_directory) | The source directory to become the bucket's root directory. If empty uses `files` subdirectory of a Terraform configuration root directory. | `string` | `""` | no |
+| <a name="input_tplname"></a> [tplname](#input\_tplname) | The Panorama template stack name. | `string` | `""` | no |
+| <a name="input_vm-auth-key"></a> [vm-auth-key](#input\_vm-auth-key) | Virtual machine authentication key. | `string` | `""` | no |
 
-  iam_instance_profile = "${module.panos-bootstrap.instance_profile_name}"
-  user_data            = "${base64encode(join("", list("vmseries-bootstrap-aws-s3bucket=", module.panos-bootstrap.bootstrap_id)))}"
+## Outputs
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags)}"
-}
-```
-
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | Global domain name of the bucket. |
+| <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | AWS identifier of the bucket. |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the bucket. |
+| <a name="output_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#output\_bucket\_regional\_domain\_name) | Regional domain name of the bucket. |
+| <a name="output_instance_profile_name"></a> [instance\_profile\_name](#output\_instance\_profile\_name) | Name of created IAM instance profile. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## References
 * [VM-Series Firewall Bootstrap Workflow](https://docs.paloaltonetworks.com/vm-series/10-0/vm-series-deployment/bootstrap-the-vm-series-firewall/vm-series-firewall-bootstrap-workflow.html#id59fe5979-c29d-42aa-8e72-14a2c12855f6)

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -2,8 +2,21 @@ resource "random_id" "bucket_id" {
   byte_length = 8
 }
 
+locals {
+  bucket_name   = coalesce(var.bucket_name, "${var.prefix}${random_id.bucket_id.hex}")
+  aws_s3_bucket = var.create_bucket ? aws_s3_bucket.this[0] : data.aws_s3_bucket.this[0]
+}
+
+data "aws_s3_bucket" "this" {
+  count = var.create_bucket == false ? 1 : 0
+
+  bucket = local.bucket_name
+}
+
 resource "aws_s3_bucket" "this" {
-  bucket        = "${var.prefix}${random_id.bucket_id.hex}"
+  count = var.create_bucket == true ? 1 : 0
+
+  bucket        = local.bucket_name
   acl           = "private"
   force_destroy = var.force_destroy
   tags          = var.global_tags
@@ -12,7 +25,7 @@ resource "aws_s3_bucket" "this" {
 resource "aws_s3_bucket_object" "bootstrap_dirs" {
   for_each = toset(var.bootstrap_directories)
 
-  bucket  = aws_s3_bucket.this.id
+  bucket  = local.aws_s3_bucket.id
   key     = each.value
   content = "/dev/null"
 }
@@ -20,7 +33,7 @@ resource "aws_s3_bucket_object" "bootstrap_dirs" {
 resource "aws_s3_bucket_object" "init_cfg" {
   count = contains(fileset(local.source_root_directory, "**"), "config/init-cfg.txt") ? 0 : 1
 
-  bucket = aws_s3_bucket.this.id
+  bucket = local.aws_s3_bucket.id
   key    = "config/init-cfg.txt"
   content = templatefile("${path.module}/init-cfg.txt.tmpl",
     {
@@ -45,7 +58,7 @@ locals {
 resource "aws_s3_bucket_object" "bootstrap_files" {
   for_each = fileset(local.source_root_directory, "**")
 
-  bucket = aws_s3_bucket.this.id
+  bucket = local.aws_s3_bucket.id
   key    = each.value
   source = "${local.source_root_directory}/${each.value}"
 }
@@ -80,12 +93,12 @@ resource "aws_iam_role_policy" "bootstrap" {
     {
       "Effect": "Allow",
       "Action": "s3:ListBucket",
-      "Resource": "arn:aws:s3:::${aws_s3_bucket.this.bucket}"
+      "Resource": "arn:aws:s3:::${local.aws_s3_bucket.bucket}"
     },
     {
     "Effect": "Allow",
     "Action": "s3:GetObject",
-    "Resource": "arn:aws:s3:::${aws_s3_bucket.this.bucket}/*"
+    "Resource": "arn:aws:s3:::${local.aws_s3_bucket.bucket}/*"
     }
   ]
 }

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -1,21 +1,21 @@
 output "bucket_id" {
-  value       = aws_s3_bucket.this.id
-  description = "AWS identifier of the created bucket."
+  value       = local.aws_s3_bucket.id
+  description = "AWS identifier of the bucket."
 }
 
 output "bucket_name" {
-  value       = aws_s3_bucket.this.bucket
-  description = "Name of the created bucket."
+  value       = local.aws_s3_bucket.bucket
+  description = "Name of the bucket."
 }
 
 output "bucket_domain_name" {
-  value       = aws_s3_bucket.this.bucket_domain_name
-  description = "Global domain name of the created bucket."
+  value       = local.aws_s3_bucket.bucket_domain_name
+  description = "Global domain name of the bucket."
 }
 
 output "bucket_regional_domain_name" {
-  value       = aws_s3_bucket.this.bucket_regional_domain_name
-  description = "Regional domain name of the created bucket."
+  value       = local.aws_s3_bucket.bucket_regional_domain_name
+  description = "Regional domain name of the bucket."
 }
 
 output "instance_profile_name" {

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -100,3 +100,15 @@ variable "plugin-op-commands" { # tflint-ignore: terraform_naming_convention # T
   default     = ""
   type        = string
 }
+
+variable "create_bucket" {
+  description = "If true, a new bucket will be created. When false, name of existing bucket to use has to be provided in `bucket_name` variable."
+  default     = true
+  type        = bool
+}
+
+variable "bucket_name" {
+  description = "Name of a bucket to reuse or create (depending on `create_bucket` value). In the latter case - if empty, the name will be auto-generated."
+  default     = ""
+  type        = string
+}

--- a/modules/gwlb/README.md
+++ b/modules/gwlb/README.md
@@ -23,6 +23,12 @@ resource aws_lb_target_group_attachment this {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.18 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.18 |
+
 ## Modules
 
 No modules.

--- a/modules/gwlb_endpoint_set/README.md
+++ b/modules/gwlb_endpoint_set/README.md
@@ -11,6 +11,12 @@ over a range of one or more Availability Zones. All the Endpoints transfer the t
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.18 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.18 |
+
 ## Modules
 
 No modules.

--- a/modules/nat_gateway_set/README.md
+++ b/modules/nat_gateway_set/README.md
@@ -42,6 +42,12 @@ module "nat_gateway_set" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/nlb/README.md
+++ b/modules/nlb/README.md
@@ -1,0 +1,96 @@
+# Palo Alto Networks Network Load Balancer Module for AWS
+
+A Terraform module for deploying a Network Load Balancer in AWS cloud. This can be used both as a public facing Load Balancer (to balance incoming traffic to Firewalls) or as an internal Load Balancer (to balance traffic from Firewalls to the actual application.)
+
+## Usage
+
+Example usage as a public Load Balancer:
+
+* The code below is designed to be used with [`vmseries`](../vmseries/README.md), [`vpc`](../vpc/README.md) and [`subnet_set`](../subnet_set/README.md) modules. Check these modules for information on outputs used in this code.
+* Firewalls' public facing interfaces are placed in a subnet set called *untrust*.
+* Health check port is set to `80` because it uses the HTTP Management Service (restricted on the firewall to Load Balancer's private IP only). Do not use SSH Management Service for health checks - [please follow this document for details](https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA14u000000oM4KCAU&lang=en_US%E2%80%A9).
+
+```
+module "public_nlb" {
+  source = "../../modules/nlb"
+
+  lb_name                 = "public-nlb"
+  create_dedicated_eips   = true
+  subnets                 = { for k, v in module.security_subnet_sets["untrust"].subnets : k => { id = v.id } }
+  vpc_id                  = module.security_vpc.id
+  balance_rules = {
+    "HTTP-traffic" = {
+      protocol          = "TCP"
+      port              = "80"
+      health_check_port = "80"
+      threshold         = 2
+      interval          = 10
+      target_type       = "ip"
+      target_port       = 8080
+      targets           = { for k, v in var.vmseries : k => module.vmseries[k].interfaces["untrust"].private_ip }
+      stickiness        = true
+    }
+    "HTTPS-traffic" = {
+      protocol          = "TCP"
+      port              = "443"
+      health_check_port = "80"
+      threshold         = 2
+      interval          = 10
+      target_port       = 8443
+      target_type       = "ip"
+      targets           = { for k, v in var.vmseries : k => module.vmseries[k].interfaces["untrust"].private_ip }
+      stickiness        = true
+    }
+  }
+
+  tags = var.global_tags
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.74 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.74 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eip.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_lb.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_balance_rules"></a> [balance\_rules](#input\_balance\_rules) | An object that contains the listener, target group, and health check configuration. <br>It consist of maps of applications like follows:<pre>balance_rules = {<br>  "application_name" = {<br>    protocol            = "communication protocol, since this is a NLB module accepted values are TCP or TLS"<br>    port                = "communication port"<br>    target_type         = "type of the target that will be attached to a target group, no defaults here, has to be provided explicitly (regardless the defaults terraform could accept)"<br>    target_port         = "for target types supporting port values, the port number on which the target accepts communication, defaults to the communication port value"<br>    targets             = "a map of targets, where key is the target name (used to create a name for the target attachment), value is the target ID (IP, resource ID, etc - the actual value depends on the target type)"<br><br>    health_check_port   = "port used by the target group healthcheck, if ommited, `traffic-port` will be used"<br>    threshold           = "number of consecutive health checks before considering target healthy or unhealthy, defaults to 3"<br>    interval            = "time between each health check, between 5 and 300 seconds, defaults to 30s"<br><br>    certificate_arn     = "(TLS ONLY) this is the arn of a certificate"<br>    alpn_policy         = "(TLS ONLY) ALPN policy name, for possible values check (terraform documentation)[https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener#alpn_policy], defaults to `None`"<br>  }<br>}</pre>The `application_name` key is valid only for letters, numbers and a dash (`-`) - that's an AWS limitation.<br><br><hr><br>`protocol` and `port` are used for `listener`, `target group` and `target group attachment`. Partially also for health checks (see below).<br><br><hr><br>All listeners are always of forward action.<br><br><hr><br>If you add FWs as targets, make sure you use `target_type = "ip"` and you provide the correct FW IPs in `target` map. IPs should be from the subnet set that the Load Balancer was created in. An example on how to feed this variable with data:<pre>fw_instance_ips = { for k, v in var.vmseries : k => module.vmseries[k].interfaces["untrust"].private_ip }</pre>For format of `var.vmseries` check the (`vmseries` module)[../vmseries/README.md]. The key is the VM name. By using those keys, we can loop through all vmseries modules and take the private IP from the interface that is assigned to the subnet we require. The subnet can be identified by the subnet set name (like above). In other words, the `for` loop returns the following map:<pre>{<br>  vm01 = "1.1.1.1"<br>  vm02 = "2.2.2.2"<br>  ...<br>}</pre><hr><br>Healthchecks are by default of type TCP. Reason for that is the fact, that HTTP requests might flow through the FW to the actual application. So instead of checking the status of the FW we might check the status of the application.<br><br>You have an option to specify a health check port. This way you can set up a Management Profile with an Administrative Management Service limited only to NLBs private IPs and use a port for that service as the health check port. This way you make sure you separate the actual health check from the application rule's port.<br><br><hr><br>EXAMPLE<pre>balance_rules = {<br>  "HTTPS-APP" = {<br>    protocol          = "TCP"<br>    port              = "443"<br>    health_check_port = "80"<br>    threshold         = 2<br>    interval          = 10<br>    target_port       = 8443<br>    target_type       = "ip"<br>    targets           = { for k, v in var.vmseries : k => module.vmseries[k].interfaces["untrust"].private_ip }<br>    stickiness        = true<br>  }<br>}</pre> | `any` | n/a | yes |
+| <a name="input_create_dedicated_eips"></a> [create\_dedicated\_eips](#input\_create\_dedicated\_eips) | If set to `true`, a set of EIPs will be created for each zone/subnet. Otherwise AWS will handle IP management. | `bool` | `false` | no |
+| <a name="input_enable_cross_zone_load_balancing"></a> [enable\_cross\_zone\_load\_balancing](#input\_enable\_cross\_zone\_load\_balancing) | Enable load balancing between instances in different AZs. Defaults to `true`. <br>Change to `false` only if absolutely necessary. By default, there is only one FW in each AZ. <br>Turning this off means 1:1 correlation between a public IP assigned to an AZ and a FW deployed in that AZ. | `bool` | `true` | no |
+| <a name="input_internal_lb"></a> [internal\_lb](#input\_internal\_lb) | Determines if this Load Balancer will be a public (default) or an internal one. | `bool` | `false` | no |
+| <a name="input_lb_name"></a> [lb\_name](#input\_lb\_name) | Name of the Load Balancer to be created | `string` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Map of subnets used with a Network Load Balancer. Each map's key is the availability zone name and the value is an object that has an attribute<br>`id` identifying AWS subnet.<br><br>Examples:<br><br>You can define the values directly:<pre>subnets = {<br>  "us-east-1a" = { id = "snet-123007" }<br>  "us-east-1b" = { id = "snet-123008" }<br>}</pre>You can also use output from the `subnet_sets` module:<pre>subnets        = { for k, v in module.subnet_sets["untrust"].subnets : k => { id = v.id } }</pre> | <pre>map(object({<br>    id = string<br>  }))</pre> | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Map of AWS tags to apply to all the created resources. | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the security VPC the Load Balancer should be created in. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_lb_fqdn"></a> [lb\_fqdn](#output\_lb\_fqdn) | A FQDN for the Load Balancer. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nlb/main.tf
+++ b/modules/nlb/main.tf
@@ -1,0 +1,123 @@
+locals {
+  # Boolean that agregates initial conditions on the type of the Load Balancer that will be created.
+  # It is used later in several places related to the way me map the Load Balancer to the subnets.
+  public_lb_with_eip = var.create_dedicated_eips && !var.internal_lb
+
+  # `target_attachments` is a flattened version of `var.balance_rules`, it contains maps of target attachments' properties.
+  # Each map contains target `id`, `port` and `app_name`, which is a key used to reference the actual target group instance.
+  # It is used only for `aws_lb_target_group_attachment` resource.
+  fw_instance_list = flatten([
+    for k, v in var.balance_rules : [
+      for target_name, target_id in v.targets :
+      {
+        app_name = k
+        name     = target_name
+        id       = target_id
+        port     = try(v.target_port, v.port)
+      }
+    ]
+  ])
+
+  target_attachments = {
+    for v in local.fw_instance_list :
+    "${v.app_name}-${v.name}" => {
+      app_name = v.app_name
+      id       = v.id
+      port     = v.port
+    }
+  }
+}
+
+resource "aws_eip" "this" {
+  for_each = local.public_lb_with_eip ? var.subnets : {}
+
+  tags = merge({ Name = "${var.lb_name}-eip-${each.key}" }, var.tags)
+}
+
+resource "aws_lb" "this" {
+  name                             = var.lb_name
+  internal                         = var.internal_lb
+  load_balancer_type               = "network"
+  enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing
+
+  # If we relay on AWS to manage public IPs we use `subnets` to attach a Load Balancer with a subnet.
+  # We use `subnets` property also for non-public LBs.
+  # On the contrary, if we would like to have a public Load Balancer with our own EIPs
+  # we need to assign them to a subnet explicitly, therefore we use `subnet mapping`.
+  # The code below does the proper use of `subnets` and `subnet_mapping`
+  # based on the use cases described above.
+  #
+  # Generally, the decision is being made on a fact if we have a public Load Balancer 
+  # with dedicated EIPs or not.
+  subnets = local.public_lb_with_eip ? null : [for k, v in var.subnets : v.id]
+  dynamic "subnet_mapping" {
+    for_each = local.public_lb_with_eip ? var.subnets : {}
+
+    content {
+      subnet_id     = subnet_mapping.value.id
+      allocation_id = aws_eip.this[subnet_mapping.key].id
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lb_target_group" "this" {
+  for_each = var.balance_rules
+
+  name        = "${var.lb_name}-tg-${each.key}"
+  vpc_id      = var.vpc_id
+  port        = try(each.value.target_port, each.value.port)
+  protocol    = each.value.protocol
+  target_type = each.value.target_type
+
+
+  health_check {
+    healthy_threshold   = try(each.value.threshold, null)
+    unhealthy_threshold = try(each.value.threshold, null)
+    interval            = try(each.value.interval, null)
+    protocol            = "TCP"
+    port                = try(each.value.health_check_port, "traffic-port")
+  }
+
+  dynamic "stickiness" {
+    # For TLS stickiness is not supported, see link:
+    # https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#sticky-sessions#:~:text=Sticky%20sessions%20are%20not%20supported%20with%20TLS%20listeners%20and%20TLS%20target%20groups.
+    for_each = each.value.stickiness && each.value.protocol != "TLS" ? [1] : []
+
+    content {
+      enabled = true
+      type    = "source_ip"
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lb_target_group_attachment" "this" {
+  for_each = local.target_attachments
+
+  target_group_arn = aws_lb_target_group.this[each.value.app_name].arn
+  target_id        = each.value.id
+  port             = each.value.port
+}
+
+resource "aws_lb_listener" "this" {
+  for_each = var.balance_rules
+
+  load_balancer_arn = aws_lb.this.arn
+  port              = each.value.port
+  protocol          = each.value.protocol
+
+  # TLS specific values
+  certificate_arn = each.value.protocol == "TLS" ? try(each.value.certificate_arn, null) : null
+  alpn_policy     = each.value.protocol == "TLS" ? try(each.value.alpn_policy, "None") : null
+
+  # This is meant to be a typical Layer4 LB, so the only supported action is `forward`.
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this[each.key].arn
+  }
+
+  tags = var.tags
+}

--- a/modules/nlb/outputs.tf
+++ b/modules/nlb/outputs.tf
@@ -1,0 +1,4 @@
+output "lb_fqdn" {
+  description = "A FQDN for the Load Balancer."
+  value       = aws_lb.this.dns_name
+}

--- a/modules/nlb/variables.tf
+++ b/modules/nlb/variables.tf
@@ -1,0 +1,146 @@
+variable "lb_name" {
+  description = "Name of the Load Balancer to be created"
+  type        = string
+}
+
+variable "create_dedicated_eips" {
+  description = "If set to `true`, a set of EIPs will be created for each zone/subnet. Otherwise AWS will handle IP management."
+  default     = false
+  type        = bool
+}
+
+variable "internal_lb" {
+  description = "Determines if this Load Balancer will be a public (default) or an internal one."
+  default     = false
+  type        = bool
+}
+
+
+variable "subnets" {
+  description = <<-EOF
+  Map of subnets used with a Network Load Balancer. Each map's key is the availability zone name and the value is an object that has an attribute
+  `id` identifying AWS subnet.
+  
+  Examples:
+
+  You can define the values directly:
+
+  ```
+  subnets = {
+    "us-east-1a" = { id = "snet-123007" }
+    "us-east-1b" = { id = "snet-123008" }
+  }
+  ```
+
+  You can also use output from the `subnet_sets` module:
+  
+  ```
+  subnets        = { for k, v in module.subnet_sets["untrust"].subnets : k => { id = v.id } }
+  ```
+  
+  EOF
+  type = map(object({
+    id = string
+  }))
+}
+
+variable "enable_cross_zone_load_balancing" {
+  description = <<-EOF
+  Enable load balancing between instances in different AZs. Defaults to `true`. 
+  Change to `false` only if absolutely necessary. By default, there is only one FW in each AZ. 
+  Turning this off means 1:1 correlation between a public IP assigned to an AZ and a FW deployed in that AZ.
+  EOF
+
+  default = true
+  type    = bool
+}
+
+variable "vpc_id" {
+  description = "ID of the security VPC the Load Balancer should be created in."
+  type        = string
+}
+
+variable "balance_rules" {
+  description = <<-EOF
+  An object that contains the listener, target group, and health check configuration. 
+  It consist of maps of applications like follows:
+
+  ```
+  balance_rules = {
+    "application_name" = {
+      protocol            = "communication protocol, since this is a NLB module accepted values are TCP or TLS"
+      port                = "communication port"
+      target_type         = "type of the target that will be attached to a target group, no defaults here, has to be provided explicitly (regardless the defaults terraform could accept)"
+      target_port         = "for target types supporting port values, the port number on which the target accepts communication, defaults to the communication port value"
+      targets             = "a map of targets, where key is the target name (used to create a name for the target attachment), value is the target ID (IP, resource ID, etc - the actual value depends on the target type)"
+
+      health_check_port   = "port used by the target group healthcheck, if ommited, `traffic-port` will be used"
+      threshold           = "number of consecutive health checks before considering target healthy or unhealthy, defaults to 3"
+      interval            = "time between each health check, between 5 and 300 seconds, defaults to 30s"
+
+      certificate_arn     = "(TLS ONLY) this is the arn of a certificate"
+      alpn_policy         = "(TLS ONLY) ALPN policy name, for possible values check (terraform documentation)[https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener#alpn_policy], defaults to `None`"
+    }
+  }
+  ```
+
+  The `application_name` key is valid only for letters, numbers and a dash (`-`) - that's an AWS limitation.
+
+  <hr>
+  `protocol` and `port` are used for `listener`, `target group` and `target group attachment`. Partially also for health checks (see below).
+
+  <hr>
+  All listeners are always of forward action.
+
+  <hr>
+  If you add FWs as targets, make sure you use `target_type = "ip"` and you provide the correct FW IPs in `target` map. IPs should be from the subnet set that the Load Balancer was created in. An example on how to feed this variable with data:
+
+  ```
+  fw_instance_ips = { for k, v in var.vmseries : k => module.vmseries[k].interfaces["untrust"].private_ip }
+  ```
+
+  For format of `var.vmseries` check the (`vmseries` module)[../vmseries/README.md]. The key is the VM name. By using those keys, we can loop through all vmseries modules and take the private IP from the interface that is assigned to the subnet we require. The subnet can be identified by the subnet set name (like above). In other words, the `for` loop returns the following map:
+
+  ```
+  {
+    vm01 = "1.1.1.1"
+    vm02 = "2.2.2.2"
+    ...
+  }
+  ```
+
+  <hr>
+  Healthchecks are by default of type TCP. Reason for that is the fact, that HTTP requests might flow through the FW to the actual application. So instead of checking the status of the FW we might check the status of the application.
+
+  You have an option to specify a health check port. This way you can set up a Management Profile with an Administrative Management Service limited only to NLBs private IPs and use a port for that service as the health check port. This way you make sure you separate the actual health check from the application rule's port.
+
+  <hr>
+  EXAMPLE
+
+  ```
+  balance_rules = {
+    "HTTPS-APP" = {
+      protocol          = "TCP"
+      port              = "443"
+      health_check_port = "80"
+      threshold         = 2
+      interval          = 10
+      target_port       = 8443
+      target_type       = "ip"
+      targets           = { for k, v in var.vmseries : k => module.vmseries[k].interfaces["untrust"].private_ip }
+      stickiness        = true
+    }
+  }
+  ```
+  EOF
+  # For the moment there is no other possibility to specify a `type` for this kind of variable.
+  # Even `map(any)` is to restrictive as it requires that all map elements must have the same type.
+  # Actually, in our case they have the same type, but they differ in the mount of inner elements.
+  type = any
+}
+
+variable "tags" {
+  description = "Map of AWS tags to apply to all the created resources."
+  default     = {}
+  type        = map(string)
+}

--- a/modules/nlb/versions.tf
+++ b/modules/nlb/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13.7, < 2.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.74"
+    }
+  }
+}

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -16,6 +16,12 @@ For usage, check the "examples" folder in the root of the repository.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/subnet_set/README.md
+++ b/modules/subnet_set/README.md
@@ -36,6 +36,12 @@ module "subnet_sets" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/transit_gateway/README.md
+++ b/modules/transit_gateway/README.md
@@ -17,6 +17,12 @@ For example usage, please refer to the [Examples](https://github.com/PaloAltoNet
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/transit_gateway_attachment/README.md
+++ b/modules/transit_gateway_attachment/README.md
@@ -16,6 +16,12 @@ For example usage, please refer to the [Examples](https://github.com/PaloAltoNet
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/transit_gateway_peering/README.md
+++ b/modules/transit_gateway_peering/README.md
@@ -41,6 +41,13 @@ The static routes are currently not handled by this module.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15, < 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+| <a name="provider_aws.remote"></a> [aws.remote](#provider\_aws.remote) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -14,6 +14,12 @@ For example usage, please refer to the [Examples](https://github.com/PaloAltoNet
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.74 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.74 |
+
 ## Modules
 
 No modules.
@@ -29,6 +35,7 @@ No modules.
 | [aws_network_interface_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface_attachment) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
+| [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
 
 ## Inputs
 

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -63,7 +63,7 @@ resource "aws_eip_association" "this" {
 # Create PA VM-series instances
 resource "aws_instance" "this" {
 
-  ami                                  = coalesce(var.vmseries_ami_id, data.aws_ami.this[0].id)
+  ami                                  = coalesce(var.vmseries_ami_id, try(data.aws_ami.this[0].id, null))
   iam_instance_profile                 = var.iam_instance_profile
   instance_type                        = var.instance_type
   key_name                             = var.ssh_key_name

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -16,7 +16,14 @@ data "aws_ami" "this" {
 }
 
 # The default EBS encryption KMS key in the current region.
-data "aws_ebs_default_kms_key" "current" {}
+data "aws_ebs_default_kms_key" "current" {
+  count = var.ebs_encrypted && var.ebs_kms_key_id == null ? 1 : 0
+}
+
+data "aws_kms_alias" "current_arn" {
+  count = var.ebs_encrypted && var.ebs_kms_key_id == null ? 1 : 0
+  name  = data.aws_ebs_default_kms_key.current[0].key_arn
+}
 
 # Network Interfaces
 resource "aws_network_interface" "this" {
@@ -70,7 +77,7 @@ resource "aws_instance" "this" {
   root_block_device {
     delete_on_termination = true
     encrypted             = var.ebs_encrypted
-    kms_key_id            = var.ebs_encrypted == false ? null : var.ebs_kms_key_id != null ? var.ebs_kms_key_id : data.aws_ebs_default_kms_key.current.key_arn
+    kms_key_id            = var.ebs_encrypted == false ? null : var.ebs_kms_key_id != null ? var.ebs_kms_key_id : data.aws_kms_alias.current_arn[0].target_key_arn
     tags                  = merge(var.tags, { Name = var.name })
   }
 

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -31,6 +31,12 @@ module "vpc" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/vpc_route/README.md
+++ b/modules/vpc_route/README.md
@@ -67,6 +67,12 @@ module "vpc_route" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -49,7 +49,7 @@ pep517==0.10.0
     #   pip-tools
 pip-tools==6.1.0
     # via -r requirements.txt
-pre-commit==2.7.1
+pre-commit==2.17.0
     # via -r requirements.txt
 pyyaml==5.4.1
     # via


### PR DESCRIPTION
## Description

In the current approach, when vmseries' disk should be encrypted but no KMS key is provided a default one is used. We reference to that key by an alias. After applying the changes the key is stored in state file with it's full ARN.

## Motivation and Context

In situation where someone would like to use a default key to encrypt vmseries' disk one will end up in a loop of recreating the VM each time `terraform` is run. It's due to the fact that in state file ARN for the key is stored, but in the code we use an alias to the actual key. This mismatch causes `terraform` to recreate a VM.

We use an alias because this is what AWS is returning when queried for a default key.

Solution: take the alias and resolve it to a full ARN then use that value to reference the key further in the code.

## How Has This Been Tested?

A vmseries VM was created with the default encryption key. After that `terraform plan` was run to see if no changes are introduced. 

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
