### PR TITLE
feat(bootstrap): add support for existing bucket

### DIFF
--- a/examples/standalone_vmseries_with_userdata_bootstrap/README.md
+++ b/examples/standalone_vmseries_with_userdata_bootstrap/README.md
@@ -43,6 +43,10 @@ terraform destroy
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.74 |
 
+## Providers
+
+No providers.
+
 ## Modules
 
 | Name | Source | Version |

--- a/examples/tgw_inbound_combined_with_gwlb/README.md
+++ b/examples/tgw_inbound_combined_with_gwlb/README.md
@@ -24,6 +24,12 @@ In a nutshell it means:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.74 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | = 3.74 |
+
 ## Modules
 
 | Name | Source | Version |

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -66,58 +66,73 @@ variables and associated values.
 8. Validate the plan using the `terraform plan` command.
 9. Apply the plan using the `terraform apply` command. 
 
-## Utilization
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
 
-The module output will provide values for the `bucket_id` and 
-`instance_profile_name`.  The `bucket_id` value can then be used in a
-`aws_instance` resource to instantiate a VM-Series instance.  It is used in
-the `user-data` parameter.  The `instance_profile_name` value is used in the
-`iam_instance_profile` parameter.  Both are neeeded to define the location of
-the S3 bootstrap bucket and the permissions needed to access it.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~>3.0 |
 
-```terraform
-resource "aws_instance" "fw" {
-  ami           = "${data.aws_ami.fw_ami.id}"
-  instance_type = "${var.fw_instance_type}"
-  key_name      = "${var.ssh_key_name}"
+## Providers
 
-  disable_api_termination              = false
-  instance_initiated_shutdown_behavior = "stop"
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~>3.0 |
 
-  ebs_optimized = true
+## Modules
 
-  root_block_device {
-    volume_type           = "gp2"
-    delete_on_termination = true
-  }
+No modules.
 
-  network_interface {
-    device_index         = 0
-    network_interface_id = "${aws_network_interface.fw_mgmt.id}"
-  }
+## Resources
 
-  network_interface {
-    device_index         = 1
-    network_interface_id = "${aws_network_interface.fw_eth1.id}"
-  }
+| Name | Type |
+|------|------|
+| [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.bootstrap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_object.bootstrap_dirs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_object.bootstrap_files](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_object.init_cfg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [random_id.bucket_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
-  network_interface {
-    device_index         = 2
-    network_interface_id = "${aws_network_interface.fw_eth2.id}"
-  }
+## Inputs
 
-  network_interface {
-    device_index         = 3
-    network_interface_id = "${aws_network_interface.fw_eth3.id}"
-  }
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bootstrap_directories"></a> [bootstrap\_directories](#input\_bootstrap\_directories) | List of subdirectories to be created inside the bucket (whether or not they exist locally inside the `source_root_directory`). A hardcoded pan-os requirement. | `list(string)` | <pre>[<br>  "config/",<br>  "content/",<br>  "software/",<br>  "license/",<br>  "plugins/"<br>]</pre> | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the bucket to create. If empty, name will be auto-generated.. | `string` | `""` | no |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Re-use existing bucket. | `bool` | `true` | no |
+| <a name="input_dgname"></a> [dgname](#input\_dgname) | The Panorama device group name. | `string` | `""` | no |
+| <a name="input_dns-primary"></a> [dns-primary](#input\_dns-primary) | The IP address of the primary DNS server. | `string` | `""` | no |
+| <a name="input_dns-secondary"></a> [dns-secondary](#input\_dns-secondary) | The IP address of the secondary DNS server. | `string` | `""` | no |
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Set to false to prevent Terraform from destroying a bucket with unknown objects or locked objects. | `bool` | `true` | no |
+| <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Map of arbitrary tags to apply to all resources. | `map(any)` | `{}` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | The hostname of the VM-series instance. | `string` | `""` | no |
+| <a name="input_iam_instance_profile_name"></a> [iam\_instance\_profile\_name](#input\_iam\_instance\_profile\_name) | Name of the instance profile to create. If empty, name will be auto-generated. | `string` | `""` | no |
+| <a name="input_op-command-modes"></a> [op-command-modes](#input\_op-command-modes) | Set jumbo-frame and/or mgmt-interface-swap. | `string` | `""` | no |
+| <a name="input_panorama-server"></a> [panorama-server](#input\_panorama-server) | The FQDN or IP address of the primary Panorama server. | `string` | `""` | no |
+| <a name="input_panorama-server2"></a> [panorama-server2](#input\_panorama-server2) | The FQDN or IP address of the secondary Panorama server. | `string` | `""` | no |
+| <a name="input_plugin-op-commands"></a> [plugin-op-commands](#input\_plugin-op-commands) | Set plugin-op-commands. | `string` | `""` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix to use for bucket name, IAM role name, and IAM role policy name. It is allowed to use dash "-" as the last character. | `string` | `"bootstrap-"` | no |
+| <a name="input_source_root_directory"></a> [source\_root\_directory](#input\_source\_root\_directory) | The source directory to become the bucket's root directory. If empty uses `files` subdirectory of a Terraform configuration root directory. | `string` | `""` | no |
+| <a name="input_tplname"></a> [tplname](#input\_tplname) | The Panorama template stack name. | `string` | `""` | no |
+| <a name="input_vm-auth-key"></a> [vm-auth-key](#input\_vm-auth-key) | Virtual machine authentication key. | `string` | `""` | no |
 
-  iam_instance_profile = "${module.panos-bootstrap.instance_profile_name}"
-  user_data            = "${base64encode(join("", list("vmseries-bootstrap-aws-s3bucket=", module.panos-bootstrap.bootstrap_id)))}"
+## Outputs
 
-  tags = "${merge(map("Name", format("%s", var.name)), var.tags)}"
-}
-```
-
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | Global domain name of the created bucket. |
+| <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | AWS identifier of the created bucket. |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the created bucket. |
+| <a name="output_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#output\_bucket\_regional\_domain\_name) | Regional domain name of the created bucket. |
+| <a name="output_instance_profile_name"></a> [instance\_profile\_name](#output\_instance\_profile\_name) | Name of created IAM instance profile. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## References
 * [VM-Series Firewall Bootstrap Workflow](https://docs.paloaltonetworks.com/vm-series/10-0/vm-series-deployment/bootstrap-the-vm-series-firewall/vm-series-firewall-bootstrap-workflow.html#id59fe5979-c29d-42aa-8e72-14a2c12855f6)

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -105,7 +105,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bootstrap_directories"></a> [bootstrap\_directories](#input\_bootstrap\_directories) | List of subdirectories to be created inside the bucket (whether or not they exist locally inside the `source_root_directory`). A hardcoded pan-os requirement. | `list(string)` | <pre>[<br>  "config/",<br>  "content/",<br>  "software/",<br>  "license/",<br>  "plugins/"<br>]</pre> | no |
-| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the bucket to create. If empty, name will be auto-generated.. | `string` | `""` | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of a bucket to reuse or create (depending on `create_bucket` value). In the latter case - if empty, the name will be auto-generated. | `string` | `""` | no |
 | <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | If true, a new bucket will be created. When false, name of existing bucket to use has to be provided in `bucket_name` variable. | `bool` | `true` | no |
 | <a name="input_dgname"></a> [dgname](#input\_dgname) | The Panorama device group name. | `string` | `""` | no |
 | <a name="input_dns-primary"></a> [dns-primary](#input\_dns-primary) | The IP address of the primary DNS server. | `string` | `""` | no |

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -106,7 +106,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bootstrap_directories"></a> [bootstrap\_directories](#input\_bootstrap\_directories) | List of subdirectories to be created inside the bucket (whether or not they exist locally inside the `source_root_directory`). A hardcoded pan-os requirement. | `list(string)` | <pre>[<br>  "config/",<br>  "content/",<br>  "software/",<br>  "license/",<br>  "plugins/"<br>]</pre> | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of the bucket to create. If empty, name will be auto-generated.. | `string` | `""` | no |
-| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Re-use existing bucket. | `bool` | `true` | no |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | If true, a new bucket will be created. When false, name of existing bucket to use has to be provided in `bucket_name` variable. | `bool` | `true` | no |
 | <a name="input_dgname"></a> [dgname](#input\_dgname) | The Panorama device group name. | `string` | `""` | no |
 | <a name="input_dns-primary"></a> [dns-primary](#input\_dns-primary) | The IP address of the primary DNS server. | `string` | `""` | no |
 | <a name="input_dns-secondary"></a> [dns-secondary](#input\_dns-secondary) | The IP address of the secondary DNS server. | `string` | `""` | no |
@@ -127,10 +127,10 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | Global domain name of the created bucket. |
-| <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | AWS identifier of the created bucket. |
-| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the created bucket. |
-| <a name="output_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#output\_bucket\_regional\_domain\_name) | Regional domain name of the created bucket. |
+| <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | Global domain name of the bucket. |
+| <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | AWS identifier of the bucket. |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the bucket. |
+| <a name="output_bucket_regional_domain_name"></a> [bucket\_regional\_domain\_name](#output\_bucket\_regional\_domain\_name) | Regional domain name of the bucket. |
 | <a name="output_instance_profile_name"></a> [instance\_profile\_name](#output\_instance\_profile\_name) | Name of created IAM instance profile. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -2,8 +2,22 @@ resource "random_id" "bucket_id" {
   byte_length = 8
 }
 
+locals {
+  bucket_name   = coalesce(var.bucket_name, "${var.prefix}${random_id.bucket_id.hex}")
+  aws_s3_bucket = var.create_bucket ? aws_s3_bucket.this[0] : data.aws_s3_bucket.this[0]
+}
+
+# Either use a pre-existing resource or create a new one. So, is it a pre-existing VPC then?
+data "aws_s3_bucket" "this" {
+  count = var.create_bucket == false ? 1 : 0
+
+  bucket = local.bucket_name
+}
+
 resource "aws_s3_bucket" "this" {
-  bucket        = "${var.prefix}${random_id.bucket_id.hex}"
+  count = var.create_bucket ? 1 : 0
+
+  bucket        = local.bucket_name
   acl           = "private"
   force_destroy = var.force_destroy
   tags          = var.global_tags
@@ -12,7 +26,7 @@ resource "aws_s3_bucket" "this" {
 resource "aws_s3_bucket_object" "bootstrap_dirs" {
   for_each = toset(var.bootstrap_directories)
 
-  bucket  = aws_s3_bucket.this.id
+  bucket  = local.aws_s3_bucket.id
   key     = each.value
   content = "/dev/null"
 }
@@ -20,7 +34,7 @@ resource "aws_s3_bucket_object" "bootstrap_dirs" {
 resource "aws_s3_bucket_object" "init_cfg" {
   count = contains(fileset(local.source_root_directory, "**"), "config/init-cfg.txt") ? 0 : 1
 
-  bucket = aws_s3_bucket.this.id
+  bucket = local.aws_s3_bucket.id
   key    = "config/init-cfg.txt"
   content = templatefile("${path.module}/init-cfg.txt.tmpl",
     {
@@ -45,7 +59,7 @@ locals {
 resource "aws_s3_bucket_object" "bootstrap_files" {
   for_each = fileset(local.source_root_directory, "**")
 
-  bucket = aws_s3_bucket.this.id
+  bucket = local.aws_s3_bucket.id
   key    = each.value
   source = "${local.source_root_directory}/${each.value}"
 }
@@ -80,12 +94,12 @@ resource "aws_iam_role_policy" "bootstrap" {
     {
       "Effect": "Allow",
       "Action": "s3:ListBucket",
-      "Resource": "arn:aws:s3:::${aws_s3_bucket.this.bucket}"
+      "Resource": "arn:aws:s3:::${local.aws_s3_bucket.bucket}"
     },
     {
     "Effect": "Allow",
     "Action": "s3:GetObject",
-    "Resource": "arn:aws:s3:::${aws_s3_bucket.this.bucket}/*"
+    "Resource": "arn:aws:s3:::${local.aws_s3_bucket.bucket}/*"
     }
   ]
 }

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -7,7 +7,6 @@ locals {
   aws_s3_bucket = var.create_bucket ? aws_s3_bucket.this[0] : data.aws_s3_bucket.this[0]
 }
 
-# Either use a pre-existing resource or create a new one. So, is it a pre-existing VPC then?
 data "aws_s3_bucket" "this" {
   count = var.create_bucket == false ? 1 : 0
 
@@ -15,7 +14,7 @@ data "aws_s3_bucket" "this" {
 }
 
 resource "aws_s3_bucket" "this" {
-  count = var.create_bucket ? 1 : 0
+  count = var.create_bucket == true ? 1 : 0
 
   bucket        = local.bucket_name
   acl           = "private"

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -1,21 +1,21 @@
 output "bucket_id" {
   value       = local.aws_s3_bucket.id
-  description = "AWS identifier of the created bucket."
+  description = "AWS identifier of the bucket."
 }
 
 output "bucket_name" {
   value       = local.aws_s3_bucket.bucket
-  description = "Name of the created bucket."
+  description = "Name of the bucket."
 }
 
 output "bucket_domain_name" {
   value       = local.aws_s3_bucket.bucket_domain_name
-  description = "Global domain name of the created bucket."
+  description = "Global domain name of the bucket."
 }
 
 output "bucket_regional_domain_name" {
   value       = local.aws_s3_bucket.bucket_regional_domain_name
-  description = "Regional domain name of the created bucket."
+  description = "Regional domain name of the bucket."
 }
 
 output "instance_profile_name" {

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -1,20 +1,20 @@
 output "bucket_id" {
-  value       = aws_s3_bucket.this.id
+  value       = local.aws_s3_bucket.id
   description = "AWS identifier of the created bucket."
 }
 
 output "bucket_name" {
-  value       = aws_s3_bucket.this.bucket
+  value       = local.aws_s3_bucket.bucket
   description = "Name of the created bucket."
 }
 
 output "bucket_domain_name" {
-  value       = aws_s3_bucket.this.bucket_domain_name
+  value       = local.aws_s3_bucket.bucket_domain_name
   description = "Global domain name of the created bucket."
 }
 
 output "bucket_regional_domain_name" {
-  value       = aws_s3_bucket.this.bucket_regional_domain_name
+  value       = local.aws_s3_bucket.bucket_regional_domain_name
   description = "Regional domain name of the created bucket."
 }
 

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -108,7 +108,7 @@ variable "create_bucket" {
 }
 
 variable "bucket_name" {
-  description = "Name of the bucket to create. If empty, name will be auto-generated.."
+  description = "Name of a bucket to reuse or create (depending on `create_bucket` value). In the latter case - if empty, the name will be auto-generated."
   default     = ""
   type        = string
 }

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -102,7 +102,7 @@ variable "plugin-op-commands" { # tflint-ignore: terraform_naming_convention # T
 }
 
 variable "create_bucket" {
-  description = "Re-use existing bucket."
+  description = "If true, a new bucket will be created. When false, name of existing bucket to use has to be provided in `bucket_name` variable."
   default     = true
   type        = bool
 }

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -100,3 +100,15 @@ variable "plugin-op-commands" { # tflint-ignore: terraform_naming_convention # T
   default     = ""
   type        = string
 }
+
+variable "create_bucket" {
+  description = "Re-use existing bucket."
+  default     = true
+  type        = bool
+}
+
+variable "bucket_name" {
+  description = "Name of the bucket to create. If empty, name will be auto-generated.."
+  default     = ""
+  type        = string
+}

--- a/modules/gwlb/README.md
+++ b/modules/gwlb/README.md
@@ -23,6 +23,12 @@ resource aws_lb_target_group_attachment this {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.18 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.18 |
+
 ## Modules
 
 No modules.

--- a/modules/gwlb_endpoint_set/README.md
+++ b/modules/gwlb_endpoint_set/README.md
@@ -11,6 +11,12 @@ over a range of one or more Availability Zones. All the Endpoints transfer the t
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.18 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.18 |
+
 ## Modules
 
 No modules.

--- a/modules/nat_gateway_set/README.md
+++ b/modules/nat_gateway_set/README.md
@@ -42,6 +42,12 @@ module "nat_gateway_set" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -16,6 +16,12 @@ For usage, check the "examples" folder in the root of the repository.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/subnet_set/README.md
+++ b/modules/subnet_set/README.md
@@ -36,6 +36,12 @@ module "subnet_sets" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/transit_gateway/README.md
+++ b/modules/transit_gateway/README.md
@@ -17,6 +17,12 @@ For example usage, please refer to the [Examples](https://github.com/PaloAltoNet
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/transit_gateway_attachment/README.md
+++ b/modules/transit_gateway_attachment/README.md
@@ -16,6 +16,12 @@ For example usage, please refer to the [Examples](https://github.com/PaloAltoNet
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/transit_gateway_peering/README.md
+++ b/modules/transit_gateway_peering/README.md
@@ -41,6 +41,13 @@ The static routes are currently not handled by this module.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15, < 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+| <a name="provider_aws.remote"></a> [aws.remote](#provider\_aws.remote) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -14,6 +14,12 @@ For example usage, please refer to the [Examples](https://github.com/PaloAltoNet
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.74 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.74 |
+
 ## Modules
 
 No modules.

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -31,6 +31,12 @@ module "vpc" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.

--- a/modules/vpc_route/README.md
+++ b/modules/vpc_route/README.md
@@ -67,6 +67,12 @@ module "vpc_route" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.10 |
 
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.10 |
+
 ## Modules
 
 No modules.


### PR DESCRIPTION
## Description

New bootstrap feature allows to support existing bucket without creating new from bootstrap module. Closes #177 

## Motivation and Context

Pushing content update from terraform code is not common operation from CI/CD.
The content for vmseries update is manage by Security Teams.

## How Has This Been Tested?

The changes are comply with existing TGW example - the options can be set 

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
