### PR TITLE
fix(vmseries): fix the issue where users cannot specify `vmseries_ami_id` 

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -56,7 +56,7 @@ resource "aws_eip_association" "this" {
 # Create PA VM-series instances
 resource "aws_instance" "this" {
 
-  ami                                  = coalesce(var.vmseries_ami_id, data.aws_ami.this[0].id)
+  ami                                  = coalesce(var.vmseries_ami_id, try(data.aws_ami.this[0].id, null))
   iam_instance_profile                 = var.iam_instance_profile
   instance_type                        = var.instance_type
   key_name                             = var.ssh_key_name


### PR DESCRIPTION
## Description

Closing #188

> When vmseries_ami_id is specified in the vmseries module the plan errors out.

## Motivation and Context

Fix the issue in using `coalesce()` with an empty tuple in our code base.

## How Has This Been Tested?

Running the examples from the repository which reference the `vmseries` module without an issue:
- `vmseries_combined_with_gwlb_natgw`
- `standalone_vmseries_with_userdata_bootstrap`

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
