### PR TITLE
feat(vmseries): enable EBS encryption by default

### DIFF
--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -42,7 +42,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bootstrap_options"></a> [bootstrap\_options](#input\_bootstrap\_options) | VM-Series bootstrap options to provide using instance user data. Contents determine type of bootstap method to use.<br>If empty (the default), bootstrap process is not triggered at all.<br>For more information on available methods, please refer to VM-Series documentation for specific version.<br>For 10.0 docs are available [here](https://docs.paloaltonetworks.com/vm-series/10-0/vm-series-deployment/bootstrap-the-vm-series-firewall.html). | `string` | `""` | no |
-| <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether to enable EBS encryption on volumes. | `bool` | `false` | no |
+| <a name="input_ebs_encrypted"></a> [ebs\_encrypted](#input\_ebs\_encrypted) | Whether to enable EBS encryption on volumes. | `bool` | `true` | no |
 | <a name="input_ebs_kms_key_id"></a> [ebs\_kms\_key\_id](#input\_ebs\_kms\_key\_id) | The ARN for the KMS key to use for volume encryption. | `string` | `null` | no |
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM instance profile. | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type. | `string` | `"m5.xlarge"` | no |

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -15,11 +15,12 @@ data "aws_ami" "this" {
   }
 }
 
-# The default EBS encryption KMS key in the current region.
+# Use the default KMS key in the current region for EBS encryption
 data "aws_ebs_default_kms_key" "current" {
   count = var.ebs_encrypted && var.ebs_kms_key_id == null ? 1 : 0
 }
 
+# Provide an alias for the default KMS key
 data "aws_kms_alias" "current_arn" {
   count = var.ebs_encrypted && var.ebs_kms_key_id == null ? 1 : 0
   name  = data.aws_ebs_default_kms_key.current[0].key_arn

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -51,7 +51,7 @@ variable "instance_type" {
 
 variable "ebs_encrypted" {
   description = "Whether to enable EBS encryption on volumes."
-  default     = false
+  default     = true
   type        = bool
 }
 


### PR DESCRIPTION
## Description

Enable EBS encryption by default for the `vmseries` module. Closes #191 

## Motivation and Context

Enhance security posture in our code base.

## How Has This Been Tested?

I've tested the changes by running the `standalone_vmseries_with_userdata_bootstrap` example with the `ebs_encrypted` parameter set to `true` and `false` respectively in two different AWS regions and compared the output to check whatever the default KMS key for the selected region is selected or not for the EBS encryption.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
