### PR TITLE
197-upgrade-version-of-random-provider

### DIFF
--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~>3.0"
+      version = "~>3.1"
     }
   }
 }


### PR DESCRIPTION
## Describe the bug

Mac M1-based machines require random provider to be minimum v3.1

## Expected behavior

Able to use modules on Mac M1-based machines

## Current behavior

Mac M1-based machines fail to use modules with older versions of the random provider

## Possible solution

Increase version numbers in versions.tf for the modules

## Steps to reproduce

Use modules on a Mac M1-based machine

## Your Environment

Terraform v1.1.9 on darwin_arm64
macOS 12.4