### PR TITLE
feat(module/transit-gateway): support for retrieving existing TGWs by ID only

### DIFF
--- a/modules/transit_gateway/README.md
+++ b/modules/transit_gateway/README.md
@@ -45,10 +45,10 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_asn"></a> [asn](#input\_asn) | BGP Autonomous System Number of the AWS Transit Gateway. | `number` | `65200` | no |
 | <a name="input_auto_accept_shared_attachments"></a> [auto\_accept\_shared\_attachments](#input\_auto\_accept\_shared\_attachments) | See the [provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway). | `string` | `null` | no |
-| <a name="input_create"></a> [create](#input\_create) | n/a | `bool` | `true` | no |
+| <a name="input_create"></a> [create](#input\_create) | Trigger module mode between creating a new TGW or retrieving an existing one. | `bool` | `true` | no |
 | <a name="input_dns_support"></a> [dns\_support](#input\_dns\_support) | See the [provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway). | `string` | `null` | no |
 | <a name="input_id"></a> [id](#input\_id) | ID of an existing Transit Gateway. Used in conjunction with `create = false`. When set, takes precedence over `var.name`. | `string` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | Name tag for the Transit Gateway and associated resources. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name tag for the Transit Gateway and associated resources. | `string` | `null` | no |
 | <a name="input_ram_resource_share_name"></a> [ram\_resource\_share\_name](#input\_ram\_resource\_share\_name) | n/a | `any` | `null` | no |
 | <a name="input_route_tables"></a> [route\_tables](#input\_route\_tables) | n/a | `map` | `{}` | no |
 | <a name="input_shared_principals"></a> [shared\_principals](#input\_shared\_principals) | n/a | `map` | `{}` | no |
@@ -59,7 +59,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_name"></a> [name](#output\_name) | Same as the input `name`. |
-| <a name="output_route_tables"></a> [route\_tables](#output\_route\_tables) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | Transit Gateway Name tag. |
+| <a name="output_route_tables"></a> [route\_tables](#output\_route\_tables) | Transit Gateway's route tables. |
 | <a name="output_transit_gateway"></a> [transit\_gateway](#output\_transit\_gateway) | The entire object `aws_ec2_transit_gateway`. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/transit_gateway/README.md
+++ b/modules/transit_gateway/README.md
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_auto_accept_shared_attachments"></a> [auto\_accept\_shared\_attachments](#input\_auto\_accept\_shared\_attachments) | See the [provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway). | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | n/a | `bool` | `true` | no |
 | <a name="input_dns_support"></a> [dns\_support](#input\_dns\_support) | See the [provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway). | `string` | `null` | no |
+| <a name="input_id"></a> [id](#input\_id) | ID of an existing Transit Gateway. Used in conjunction with `create = false`. When set, takes precedence over `var.name`. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name tag for the Transit Gateway and associated resources. | `string` | n/a | yes |
 | <a name="input_ram_resource_share_name"></a> [ram\_resource\_share\_name](#input\_ram\_resource\_share\_name) | n/a | `any` | `null` | no |
 | <a name="input_route_tables"></a> [route\_tables](#input\_route\_tables) | n/a | `map` | `{}` | no |

--- a/modules/transit_gateway/main.tf
+++ b/modules/transit_gateway/main.tf
@@ -26,7 +26,7 @@ resource "aws_ec2_transit_gateway" "this" {
 
 data "aws_ec2_transit_gateway" "this" {
   count = var.create == false ? 1 : 0
-  # ID of an existing TGW. By default set to `null` hence can be reference directly.
+  # ID of an existing TGW. By default set to `null` hence can be referenced directly.
   id = var.id
 
   # Filtering existing TGWs by name, only in case no ID was provided.

--- a/modules/transit_gateway/main.tf
+++ b/modules/transit_gateway/main.tf
@@ -26,10 +26,17 @@ resource "aws_ec2_transit_gateway" "this" {
 
 data "aws_ec2_transit_gateway" "this" {
   count = var.create == false ? 1 : 0
+  # ID of an existing TGW. By default set to `null` hence can be reference directly.
+  id = var.id
 
-  filter {
-    name   = "tag:Name"
-    values = [var.name]
+  # Filtering existing TGWs by name, only in case no ID was provided.
+  dynamic "filter" {
+    for_each = var.id == null ? [1] : []
+    content {
+      name   = "tag:Name"
+      values = [var.name]
+
+    }
   }
 }
 

--- a/modules/transit_gateway/main.tf
+++ b/modules/transit_gateway/main.tf
@@ -26,9 +26,9 @@ resource "aws_ec2_transit_gateway" "this" {
 
 data "aws_ec2_transit_gateway" "this" {
   count = var.create == false ? 1 : 0
+  
   # ID of an existing TGW. By default set to `null` hence can be referenced directly.
   id = var.id
-
   # Filtering existing TGWs by name, only in case no ID was provided.
   dynamic "filter" {
     for_each = var.id == null ? [1] : []

--- a/modules/transit_gateway/main.tf
+++ b/modules/transit_gateway/main.tf
@@ -26,7 +26,7 @@ resource "aws_ec2_transit_gateway" "this" {
 
 data "aws_ec2_transit_gateway" "this" {
   count = var.create == false ? 1 : 0
-  
+
   # ID of an existing TGW. By default set to `null` hence can be referenced directly.
   id = var.id
   # Filtering existing TGWs by name, only in case no ID was provided.

--- a/modules/transit_gateway/outputs.tf
+++ b/modules/transit_gateway/outputs.tf
@@ -10,5 +10,6 @@ output "transit_gateway" {
 }
 
 output "route_tables" {
-  value = local.transit_gateway_route_tables
+  description = "Transit Gateway's route tables."
+  value       = local.transit_gateway_route_tables
 }

--- a/modules/transit_gateway/outputs.tf
+++ b/modules/transit_gateway/outputs.tf
@@ -1,6 +1,7 @@
 output "name" {
   description = "Same as the input `name`."
-  value       = var.name
+  # Referencing the actual NAME TAG gives us access to it's value for TGWs referenced only by ID.
+  value = try(local.transit_gateway.tags.Name, null)
 }
 
 output "transit_gateway" {

--- a/modules/transit_gateway/outputs.tf
+++ b/modules/transit_gateway/outputs.tf
@@ -1,5 +1,5 @@
 output "name" {
-  description = "Same as the input `name`."
+  description = "Transit Gateway Name tag."
   # Referencing the actual NAME TAG gives us access to it's value for TGWs referenced only by ID.
   value = try(local.transit_gateway.tags.Name, null)
 }

--- a/modules/transit_gateway/variables.tf
+++ b/modules/transit_gateway/variables.tf
@@ -1,9 +1,12 @@
 variable "create" {
-  default = true
+  description = "Trigger module mode between creating a new TGW or retrieving an existing one."
+  default     = true
+  type        = bool
 }
 
 variable "name" {
   description = "Name tag for the Transit Gateway and associated resources."
+  default     = null
   type        = string
 }
 

--- a/modules/transit_gateway/variables.tf
+++ b/modules/transit_gateway/variables.tf
@@ -6,6 +6,7 @@ variable "name" {
   description = "Name tag for the Transit Gateway and associated resources."
   type        = string
 }
+
 variable "id" {
   description = "ID of an existing Transit Gateway. Used in conjunction with `create = false`. When set, takes precedence over `var.name`."
   default     = null

--- a/modules/transit_gateway/variables.tf
+++ b/modules/transit_gateway/variables.tf
@@ -6,6 +6,11 @@ variable "name" {
   description = "Name tag for the Transit Gateway and associated resources."
   type        = string
 }
+variable "id" {
+  description = "ID of an existing Transit Gateway. Used in conjunction with `create = false`. When set, takes precedence over `var.name`."
+  default     = null
+  type        = string
+}
 
 variable "asn" {
   description = "BGP Autonomous System Number of the AWS Transit Gateway."


### PR DESCRIPTION
## Description

Add ability to retrieve an existing Transit Gateway using it's ID. 

## Motivation and Context

Required in situations where to `Name` tag is present or TGW is a shared one - in this case only referencing by ID is possible.

## How Has This Been Tested?

All 3 scenarios were tested:
* create a TGW
* retrieve existing by name
* retrieve existing by ID

## Screenshots (if appropriate)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist


- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
