### PR TITLE
fix(module/alb): provide unique names for tg listener attachments

### DIFF
--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -110,7 +110,7 @@ locals {
 
   # A map of target group attachments.
   listener_tg_attachments = {
-    for v in local.listener_tg_attachments_list : v.listener_tg_name => {
+    for v in local.listener_tg_attachments_list : "${v.listener_tg_name}-${v.host}" => {
       ip               = v.ip
       port             = v.port
       listener_tg_name = v.listener_tg_name


### PR DESCRIPTION
## Description

In `locals`, add target VM name to the internal map of TG attachments.

## Motivation and Context

Currently there is a bug in the `locals` logic when creating a map of unique target attachments for a particular listener rule. The bug happens when there should be more than one attachments. 

## How Has This Been Tested?

A [future](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/pull/194) example was used to test the code.  

## Screenshots (if appropriate)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
