### PR TITLE
feat(example): add endpoint bootstrap via user_data

### DIFF
--- a/examples/vmseries_combined_with_gwlb_natgw/README.md
+++ b/examples/vmseries_combined_with_gwlb_natgw/README.md
@@ -70,6 +70,7 @@ No resources.
 | <a name="input_gwlb_endpoint_set_outbound_name"></a> [gwlb\_endpoint\_set\_outbound\_name](#input\_gwlb\_endpoint\_set\_outbound\_name) | n/a | `any` | n/a | yes |
 | <a name="input_gwlb_name"></a> [gwlb\_name](#input\_gwlb\_name) | n/a | `any` | n/a | yes |
 | <a name="input_nat_gateway_name"></a> [nat\_gateway\_name](#input\_nat\_gateway\_name) | n/a | `any` | n/a | yes |
+| <a name="input_outbound_subinterface"></a> [outbound\_subinterface](#input\_outbound\_subinterface) | n/a | `any` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | ## General | `any` | n/a | yes |
 | <a name="input_security_vpc_cidr"></a> [security\_vpc\_cidr](#input\_security\_vpc\_cidr) | n/a | `any` | n/a | yes |
 | <a name="input_security_vpc_name"></a> [security\_vpc\_name](#input\_security\_vpc\_name) | n/a | `any` | n/a | yes |

--- a/examples/vmseries_combined_with_gwlb_natgw/example.tfvars
+++ b/examples/vmseries_combined_with_gwlb_natgw/example.tfvars
@@ -92,10 +92,9 @@ firewalls = {
 }
 
 bootstrap_options = {
-  mgmt-interface-swap      = "enable"
-  plugin-op-commands       = "aws-gwlb-inspect:enable"
-  aws-gwlb-overlay-routing = "enable"
-  type                     = "dhcp-client"
+  mgmt-interface-swap = "enable"
+  plugin-op-commands  = "aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable"
+  type                = "dhcp-client"
 }
 
 outbound_subinterface = "ethernet1/1.20" # Dedicated subinterface for VMSeries bootstraping

--- a/examples/vmseries_combined_with_gwlb_natgw/example.tfvars
+++ b/examples/vmseries_combined_with_gwlb_natgw/example.tfvars
@@ -91,7 +91,8 @@ firewalls = {
   vmseries02 = { az = "us-east-1b" }
 }
 
-bootstrap_options = "mgmt-interface-swap=enable;plugin-op-commands=aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable;type=dhcp-client"
+bootstrap_options     = "mgmt-interface-swap=enable;plugin-op-commands=aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable;type=dhcp-client"
+outbound_subinterface = "ethernet1/1.20" # Dedicated subinterface for VMSeries bootstraping
 
 # Security VPC routes ###
 security_vpc_routes_outbound_source_cidrs = [ # outbound traffic return after inspection

--- a/examples/vmseries_combined_with_gwlb_natgw/example.tfvars
+++ b/examples/vmseries_combined_with_gwlb_natgw/example.tfvars
@@ -91,7 +91,13 @@ firewalls = {
   vmseries02 = { az = "us-east-1b" }
 }
 
-bootstrap_options     = "mgmt-interface-swap=enable;plugin-op-commands=aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable;type=dhcp-client"
+bootstrap_options = {
+  mgmt-interface-swap      = "enable"
+  plugin-op-commands       = "aws-gwlb-inspect:enable"
+  aws-gwlb-overlay-routing = "enable"
+  type                     = "dhcp-client"
+}
+
 outbound_subinterface = "ethernet1/1.20" # Dedicated subinterface for VMSeries bootstraping
 
 # Security VPC routes ###

--- a/examples/vmseries_combined_with_gwlb_natgw/main.tf
+++ b/examples/vmseries_combined_with_gwlb_natgw/main.tf
@@ -129,12 +129,9 @@ locals {
     ],
   )
 
-  outbound = [for k, v in module.gwlbe_outbound.endpoints : format("aws-gwlb-associate-vpce:%s@%s", v.id, var.outbound_subinterface)]
-
-  bootstrap_options = join(";", compact(concat(
-    [var.bootstrap_options],
-    [for _, v in local.outbound : "${v}"]
-  )))
+  outbound          = join(",", compact(concat([for k, v in module.gwlbe_outbound.endpoints : format("aws-gwlb-associate-vpce:%s@%s", v.id, var.outbound_subinterface)])))
+  bootstrap         = [for k, v in var.bootstrap_options : k != "plugin-op-commands" ? "${k}=${v}" : "${k}=${format("%s,%s", v, local.outbound)}"]
+  bootstrap_options = join(";", compact(concat(local.bootstrap)))
 }
 
 # Security VPC Routes

--- a/examples/vmseries_combined_with_gwlb_natgw/main.tf
+++ b/examples/vmseries_combined_with_gwlb_natgw/main.tf
@@ -61,7 +61,7 @@ module "vmseries" {
   name              = each.key
   tags              = var.global_tags
   ssh_key_name      = var.ssh_key_name
-  bootstrap_options = var.bootstrap_options
+  bootstrap_options = local.bootstrap_options
   vmseries_version  = var.vmseries_version
 
   interfaces = {
@@ -128,6 +128,13 @@ locals {
       }
     ],
   )
+
+  outbound = [for k, v in module.gwlbe_outbound.endpoints : format("aws-gwlb-associate-vpce:%s@%s", v.id, var.outbound_subinterface)]
+
+  bootstrap_options = join(";", compact(concat(
+    [var.bootstrap_options],
+    [for _, v in local.outbound : "${v}"]
+  )))
 }
 
 # Security VPC Routes

--- a/examples/vmseries_combined_with_gwlb_natgw/variables.tf
+++ b/examples/vmseries_combined_with_gwlb_natgw/variables.tf
@@ -15,3 +15,4 @@ variable "nat_gateway_name" {}
 variable "firewalls" {}
 variable "bootstrap_options" {}
 variable "vmseries_version" {}
+variable "outbound_subinterface" {}


### PR DESCRIPTION
## Description

A simple change. The new feature allows push endpoint config during bootstrap VMSeries phase.

## Motivation and Context

Enabling VPC endpoint configuration requires login into VMSeries machine and run fallowing command:
```request plugins vm_series aws gwlb associate interface ethernet1/1.10 vpc-endpoint ${outbound1}```

## How Has This Been Tested?

The configuration is not available after run ```show plugins vm_series aws gwlb``` until the interface configuration
will be retrieved from Panorama, bootstrap.xml or in manual way.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->
- New feature (non-breaking change which adds functionality)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All new and existing tests passed.
