### PR TITLE
fix(modules/vmseries): avoid vmseries re-creation after user_data mod…

### DIFF
--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -6,6 +6,10 @@ A Terraform module for deploying a VM-Series firewall in AWS cloud.
 
 For example usage, please refer to the [Examples](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/tree/develop/examples) directory.
 
+## VMSeries Lifecycle policy
+
+The changes in user data bootstrap entries will not affect the existing VM-Series EC2 instances. The recommended method to replace existing VM is to use terraform taint.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -101,6 +101,12 @@ resource "aws_instance" "this" {
   }
 
   tags = merge(var.tags, { Name = var.name })
+
+  lifecycle {
+    ignore_changes = [
+      user_data,
+    ]
+  }
 }
 
 resource "aws_network_interface_attachment" "this" {


### PR DESCRIPTION
## Description

Every change on bootstrap will lead to existing VMSeries reaeration. The preferred method of VMSeries recreation is terraform tainting. 

## Motivation and Context

The change allows control what should be destroyed after adding new firewall and changing ```vm-auth-key``` using bootstrap method. The issue doesn't exist on S3 method.

## How Has This Been Tested?

The user data was updated after example environment created all resources. It leads to destroying VMSeries firewalls.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
