### PR TITLE
Enhance standalone_vmseries_with_userdata_bootstrap example

### DIFF
--- a/examples/standalone_vmseries_with_userdata_bootstrap/example.tfvars
+++ b/examples/standalone_vmseries_with_userdata_bootstrap/example.tfvars
@@ -44,7 +44,18 @@ security_vpc_security_groups = {
 ssh_key_name     = "example-ssh-key"
 vmseries_version = "10.1.3"
 vmseries = {
-  vmseries01 = { az = "us-east-1a" }
+  vmseries01 = {
+    az = "us-east-1a"
+    interfaces = {
+      mgmt = {
+        device_index      = 0
+        security_group    = "vmseries_mgmt"
+        source_dest_check = true
+        subnet            = "mgmt"
+        create_public_ip  = true
+      }
+    }
+  }
 }
 
 bootstrap_options = "plugin-op-commands=aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable;type=dhcp-client;hostname=vms01"

--- a/examples/standalone_vmseries_with_userdata_bootstrap/main.tf
+++ b/examples/standalone_vmseries_with_userdata_bootstrap/main.tf
@@ -29,12 +29,12 @@ module "vmseries" {
   ssh_key_name      = var.ssh_key_name
   bootstrap_options = var.bootstrap_options
   interfaces = {
-    mgmt = {
-      device_index       = 0
-      security_group_ids = [module.security_vpc.security_group_ids["vmseries_mgmt"]]
-      source_dest_check  = true
-      subnet_id          = module.security_subnet_sets["mgmt"].subnets[each.value.az].id
-      create_public_ip   = true
+    for k, v in each.value.interfaces : k => {
+      device_index       = v.device_index
+      security_group_ids = try([module.security_vpc.security_group_ids[v.security_group]], [])
+      source_dest_check  = v.source_dest_check
+      subnet_id          = module.security_subnet_sets[v.subnet].subnets[each.value.az].id
+      create_public_ip   = v.create_public_ip
     }
   }
 


### PR DESCRIPTION
## Description

The current example is not dynamic enough to be used during demos.

## Motivation and Context

The `standalone_vmseries_with_userdata_bootstrap` example has one interface hardcoded in the main.tf file. Whilst this is ok to get yourself familiarised with the modules, this makes it harder to consume the example via Terraform registry and deploy a firewall with multiple interfaces during demos, etc.

The proposed change adds flexibility to add additional interfaces via variables. 

## How Has This Been Tested?

Terraform apply
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
