### PR TITLE
fix: Fixed panorama/vmseries image selection

### DIFF
--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -13,6 +13,8 @@ data "aws_ami" "this" {
     name   = "product-code"
     values = [var.vmseries_product_code]
   }
+
+  name_regex = "^PA-VM-AWS-${var.vmseries_version}-[[:alnum:]]{8}-([[:alnum:]]{4}-){3}[[:alnum:]]{12}$"
 }
 
 locals {

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -7,11 +7,12 @@ data "aws_ami" "this" {
     name   = "name"
     values = ["Panorama-AWS-${var.panorama_version}*"]
   }
-
   filter {
     name   = "product-code"
     values = [var.product_code]
   }
+
+  name_regex = "^Panorama-AWS-${var.panorama_version}-[[:alnum:]]{8}-([[:alnum:]]{4}-){3}[[:alnum:]]{12}$"
 }
 
 # Create the Panorama Instance

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -13,6 +13,8 @@ data "aws_ami" "this" {
     name   = "product-code"
     values = [var.vmseries_product_code]
   }
+
+  name_regex = "^PA-VM-AWS-${var.vmseries_version}-[[:alnum:]]{8}-([[:alnum:]]{4}-){3}[[:alnum:]]{12}$"
 }
 
 # Use the default KMS key in the current region for EBS encryption


### PR DESCRIPTION
## Description

Add image name regex to match proper image from ambiguous results returned based on AWS ami filters.

## Motivation and Context

Resolves #239 

## How Has This Been Tested?

Deploy one of examples using vmseries image version specified as `10.1.6`, update value to `10.1.6-h6`,  re-apply.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
