### PR TITLE
added dedicated resource for allowed_principals on the vpc_endpoint_service

### DIFF
--- a/modules/gwlb/README.md
+++ b/modules/gwlb/README.md
@@ -42,6 +42,7 @@ No modules.
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_vpc_endpoint_service.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_service) | resource |
+| [aws_vpc_endpoint_service_allowed_principal.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint_service_allowed_principal) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs

--- a/modules/gwlb/main.tf
+++ b/modules/gwlb/main.tf
@@ -26,7 +26,7 @@ resource "aws_vpc_endpoint_service" "this" {
 
 # Dedicated resource for allowing principals, this allows for adding more principals from outside this module (Onboarding new AWS accounts adhoc)
 resource "aws_vpc_endpoint_service_allowed_principal" "this" {
-  for_each = toset(coalescelist(var.allowed_principals, ["arn:aws:iam::${data.aws_caller_identity.current.id}:root"]))
+  for_each                = toset(coalescelist(var.allowed_principals, ["arn:aws:iam::${data.aws_caller_identity.current.id}:root"]))
   vpc_endpoint_service_id = aws_vpc_endpoint_service.this.id
   principal_arn           = each.key
 }


### PR DESCRIPTION
## Description
We want to use these modules for our PaloAlto GWLB setup, however when we were trying to add a spoke account to this setup, we noticed that the vpc_endpoint_service that gets created in the gwlb module is using inline allowed_principals.
As documented by Terraform, you can't use the inline allowed_principals together with the dedicated aws_vpc_endpoint_service_allowed_principal resource. It makes sense to use the dedicated resource to allow for external (other TF) to be able to add principals to the endpoint_service without having to run the hub (GWLB) TF again.

## Motivation and Context

When creating a new AWS account (in our AWSOrganisation), we want to make it a spoke and plug it in on our security GWLB setup, at that moment we want to allow that account to be able to use the vpc_endpoint_service that is created in our hub. We do not want to add the new account in the list defined in the hub TF. Because that means we would also have to rerun the hub TF.

We can now add this code block in our other account's TF and we will be able to create VPCe on that endpoint_service

```
resource "aws_vpc_endpoint_service_allowed_principal" "this" {
  provider = aws.hub
  vpc_endpoint_service_id = "vpce-svc-000000000"
  principal_arn           = "arn:aws:iam::${data.aws_caller_identity.current.id}:root"
}
```

## How Has This Been Tested?

I tested this on my fork, the existing functionality still works the same way. However we can now add principals as described above. This allows for more flexiblity in the module.


## Types of changes

- New feature (non-breaking change which adds functionality)


## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
