### PR TITLE
feat(examples/tgw_inbound_combined_with_gwlb): associate VPC endpoints with VM-Series subinterfaces

### DIFF
--- a/examples/tgw_inbound_combined_with_gwlb/example.tfvars
+++ b/examples/tgw_inbound_combined_with_gwlb/example.tfvars
@@ -140,11 +140,11 @@ vmseries_common = {
     mgmt-interface-swap = "enable"
     plugin-op-commands  = "aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable"
   }
-  s3_bucket_init_cfg_op_command_modes   = "mgmt-interface-swap"
-  s3_bucket_init_cfg_plugin_op_commands = "aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable"
-  subinterface_inbound                  = "ethernet1/1.10"
-  subinterface_outbound                 = "ethernet1/1.20"
-  subinterface_eastwest                 = "ethernet1/1.30"
+  subinterfaces = {
+    inbound  = "ethernet1/1.10"
+    outbound = "ethernet1/1.20"
+    eastwest = "ethernet1/1.30"
+  }
 }
 vmseries_version = "10.2.2"
 

--- a/examples/tgw_inbound_combined_with_gwlb/example.tfvars
+++ b/examples/tgw_inbound_combined_with_gwlb/example.tfvars
@@ -138,7 +138,13 @@ vmseries = {
 vmseries_common = {
   bootstrap_options = {
     mgmt-interface-swap = "enable"
+    plugin-op-commands  = "aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable"
   }
+  s3_bucket_init_cfg_op_command_modes   = "mgmt-interface-swap"
+  s3_bucket_init_cfg_plugin_op_commands = "aws-gwlb-inspect:enable,aws-gwlb-overlay-routing:enable"
+  subinterface_inbound                  = "ethernet1/1.10"
+  subinterface_outbound                 = "ethernet1/1.20"
+  subinterface_eastwest                 = "ethernet1/1.30"
 }
 vmseries_version = "10.2.2"
 

--- a/examples/tgw_inbound_combined_with_gwlb/files/config/init-cfg.sample.txt
+++ b/examples/tgw_inbound_combined_with_gwlb/files/config/init-cfg.sample.txt
@@ -5,6 +5,7 @@ panorama-server-2=10.255.64.4
 tplname=my-panorama-stack
 dgname=my-panorama-device-group
 hostname=gwlbftw
+plugin-op-commands=aws-gwlb-inspect:enable
 dhcp-send-hostname=yes
 dhcp-send-client-id=yes
 dhcp-accept-server-hostname=yes

--- a/examples/tgw_inbound_combined_with_gwlb/files/config/init-cfg.sample.txt
+++ b/examples/tgw_inbound_combined_with_gwlb/files/config/init-cfg.sample.txt
@@ -5,7 +5,6 @@ panorama-server-2=10.255.64.4
 tplname=my-panorama-stack
 dgname=my-panorama-device-group
 hostname=gwlbftw
-plugin-op-commands=aws-gwlb-inspect:enable
 dhcp-send-hostname=yes
 dhcp-send-client-id=yes
 dhcp-accept-server-hostname=yes


### PR DESCRIPTION
## Description

Associate a VPC Endpoints with VM-Series Interfaces in bootstrap options.

## Motivation and Context

While preparing project for customer with GWLB, there was a need to automatically associate VPC endpoints with VM-Series subinterfaces. In this example similar option is introduced. Moreover that PR is connected with #251, in which feature with GWLB endpoints added to bootstrap options is required.

## How Has This Been Tested?

Code was tested by deploying example [tgw_inbound_combined_with_gwlb](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/tree/main/examples/tgw_inbound_combined_with_gwlb).

## Screenshots (if appropriate)

Not appropriate

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
