### PR TITLE
chore: checkov pre-commit hook crashes importing packaging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
           --args=--only=terraform_workspace_remote,
         ]
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '2.1.98'
+    rev: '2.2.125'
     hooks:
     - id: checkov
       verbose: true


### PR DESCRIPTION
## Description

Updated checkov version in pre-commit hooks to 2.2.125 that uses a pinned version of packaging module.

## Motivation and Context

It fixes issue #255

## How Has This Been Tested?

It was tested by running ``git commit`` and checking ``checkov`` output.

## Screenshots (if appropriate)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
