### PR TITLE
test: Use ResourceChangesMap to check planned changes, do not use regexp

### DIFF
--- a/tests/internal/testskeleton/testskeleton.go
+++ b/tests/internal/testskeleton/testskeleton.go
@@ -147,7 +147,7 @@ func checkResourceChange(t *testing.T, v *tfjson.ResourceChange) {
 	}
 
 	assert.False(t, hasDelete, "Resource %v is about to be deleted, but it shouldn't", v.Address)
-	assert.False(t, hasCreate, "Resource %v is about to be create, but it shouldn't", v.Address)
+	assert.False(t, hasCreate, "Resource %v is about to be created, but it shouldn't", v.Address)
 	assert.False(t, hasUpdate, "Resource %v is about to be updated, but it shouldn't", v.Address)
 }
 

--- a/tests/internal/testskeleton/testskeleton.go
+++ b/tests/internal/testskeleton/testskeleton.go
@@ -2,12 +2,12 @@ package testskeleton
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,10 +75,11 @@ func GenericDeployInfraAndVerifyAssertChanges(t *testing.T, terraformOptions *te
 
 	// Check if there are no changes planed after deployment (if checkNoChanges is true)
 	if checkNoChanges {
-		output := terraform.InitAndPlan(t, terraformOptions)
-		noInfraChangeExpectedMessage := "No changes in infrastructure are expected after deployment"
-		assert.Regexp(t, regexp.MustCompile(".*No changes.*Your infrastructure matches the configuration.*"), output, noInfraChangeExpectedMessage)
-		assert.NotRegexp(t, regexp.MustCompile(".*Plan:.*to add,.*to change,.*to destroy.*"), output, noInfraChangeExpectedMessage)
+		terraformOptions.PlanFilePath = "test.plan"
+		planStructure := terraform.InitAndPlanAndShowWithStruct(t, terraformOptions)
+		for _, v := range planStructure.ResourceChangesMap {
+			checkResourceChange(t, v)
+		}
 	}
 
 	return terraformOptions
@@ -126,6 +127,28 @@ func AssertOutputs(t *testing.T, terraformOptions *terraform.Options, assertList
 			t.Fail()
 		}
 	}
+}
+
+// Function is checking if in ResourceChangesMap from PlanStruct
+// there are planned any resources to be added, deleted or changed
+func checkResourceChange(t *testing.T, v *tfjson.ResourceChange) {
+	hasDelete, hasCreate, hasUpdate := false, false, false
+
+	for _, action := range v.Change.Actions {
+		if action == tfjson.ActionDelete {
+			hasDelete = true
+		}
+		if action == tfjson.ActionCreate {
+			hasCreate = true
+		}
+		if action == tfjson.ActionUpdate {
+			hasUpdate = true
+		}
+	}
+
+	assert.False(t, hasDelete, "Resource %v is about to be deleted, but it shouldn't", v.Address)
+	assert.False(t, hasCreate, "Resource %v is about to be create, but it shouldn't", v.Address)
+	assert.False(t, hasUpdate, "Resource %v is about to be updated, but it shouldn't", v.Address)
 }
 
 // Functions is response for planning deployment,

--- a/tests/internal/testskeleton/testskeleton.go
+++ b/tests/internal/testskeleton/testskeleton.go
@@ -132,23 +132,27 @@ func AssertOutputs(t *testing.T, terraformOptions *terraform.Options, assertList
 // Function is checking if in ResourceChangesMap from PlanStruct
 // there are planned any resources to be added, deleted or changed
 func checkResourceChange(t *testing.T, v *tfjson.ResourceChange) {
-	hasDelete, hasCreate, hasUpdate := false, false, false
+	var hasUpdate struct {
+		updated    bool
+		updateType string
+	}
 
 	for _, action := range v.Change.Actions {
 		if action == tfjson.ActionDelete {
-			hasDelete = true
+			hasUpdate.updated = true
+			hasUpdate.updateType = "deleted"
 		}
 		if action == tfjson.ActionCreate {
-			hasCreate = true
+			hasUpdate.updated = true
+			hasUpdate.updateType = "created"
 		}
 		if action == tfjson.ActionUpdate {
-			hasUpdate = true
+			hasUpdate.updated = true
+			hasUpdate.updateType = "updated"
 		}
 	}
 
-	assert.False(t, hasDelete, "Resource %v is about to be deleted, but it shouldn't", v.Address)
-	assert.False(t, hasCreate, "Resource %v is about to be created, but it shouldn't", v.Address)
-	assert.False(t, hasUpdate, "Resource %v is about to be updated, but it shouldn't", v.Address)
+	assert.False(t, hasUpdate.updated, "Resource %v is about to be %s, but it shouldn't", v.Address, hasUpdate.updateType)
 }
 
 // Functions is response for planning deployment,


### PR DESCRIPTION
## Description

Small improvements in checking, if after deployment and running Terraform plan there are planned changes. If yes, then our infrastructure code is not idempotent and test is going to detect such case.

## Motivation and Context

It's a part of #86 

## How Has This Been Tested?

It was tested using Terratest.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
