### PR TITLE
feat: Improvements needed for tests of modules and fix in panorama example

### DIFF
--- a/examples/standalone_panorama/main.tf
+++ b/examples/standalone_panorama/main.tf
@@ -59,7 +59,7 @@ module "panorama" {
   create_public_ip       = var.panorama_create_public_ip
   ebs_volumes            = var.panorama_ebs_volumes
   name                   = var.panorama_deployment_name
-  ebs_kms_key_alias      = try(data.aws_kms_alias.current_arn[0].arn, null)
+  ebs_kms_key_alias      = try(data.aws_kms_alias.current_arn[0].target_key_arn, null)
   panorama_version       = var.panorama_version
   ssh_key_name           = var.panorama_ssh_key_name
   subnet_id              = module.security_subnet_sets["mgmt"].subnets[var.panorama_az].id

--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -101,6 +101,7 @@ No modules.
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_security_group_rule.alb_att](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_elb_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -165,6 +165,18 @@ resource "aws_s3_bucket_policy" "this" {
 }
 # ######################## #
 
+## Add communication to ALB with ephemeral port
+
+resource "aws_security_group_rule" "alb_att" {
+
+  from_port                = 0
+  protocol                 = "all"
+  source_security_group_id = var.security_groups[0]
+  security_group_id        = var.security_groups[0]
+  to_port                  = 0
+  type                     = "ingress"
+}
+
 # ## Application Load Balancer ##
 resource "aws_lb" "this" {
   name                             = var.lb_name

--- a/modules/vpc_route/outputs.tf
+++ b/modules/vpc_route/outputs.tf
@@ -1,8 +1,16 @@
 output "route_details" {
   value = [for k, v in aws_route.this : {
-    cidr = v.destination_cidr_block
-    mpl  = v.destination_prefix_list_id
-    rtb  = v.route_table_id
+    cidr                               = v.destination_cidr_block
+    mpl                                = v.destination_prefix_list_id
+    rtb                                = v.route_table_id
+    next_hop_transit_gateway_id        = try(v.transit_gateway_id, null)
+    next_hop_gateway_id                = try(v.gateway_id, null)
+    next_hop_nat_gateway_id            = try(v.nat_gateway_id, null)
+    next_hop_network_interface_id      = try(v.network_interface_id, null)
+    next_hop_vpc_endpoint_id           = try(v.vpc_endpoint_id, null)
+    next_hop_vpc_peering_connection_id = try(v.vpc_peering_connection_id, null)
+    next_hop_egress_only_gateway_id    = try(v.egress_only_gateway_id, null)
+    next_hop_local_gateway_id          = try(v.local_gateway_id, null)
     }
   ]
 }


### PR DESCRIPTION
## Description

PR #257 with tests and improvements was too big, so in #257 only tests are being merged and in this PR improvements and fixes. PR delivers:
- improvements in modules:
   - ``alb`` (resource ``aws_security_group_rule`` added)
   - ``vpc_route`` (outputs from module extended)
- fixes in examples:
   -  ``standalone_panorama`` (way of retrieving KMS key ID is changed - from alias we need to pass [target_key_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias#target_key_arn), not ARN of the key alias. Problem was reported by @migara and observed during testing, in which after deployment we are checking if there is changes planned, when we run ``terraform plan`` just after deployment)


## Motivation and Context

There was a question to deliver in #257 only changes for tests 

## How Has This Been Tested?

It was tested together with #257 

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
