### PR TITLE
fix(asg): Fix possible KeyError in Lambda function on terminate lifec…

### DIFF
--- a/modules/asg/lambda.py
+++ b/modules/asg/lambda.py
@@ -128,7 +128,7 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
         """
 
         instance_info = self.ec2_client.describe_instances(InstanceIds=[instance_id])['Reservations'][0]['Instances'][0]
-        return instance_info['Placement']['AvailabilityZone'], instance_info['SubnetId'], \
+        return instance_info['Placement']['AvailabilityZone'], instance_info.get('SubnetId'), \
                instance_info['NetworkInterfaces']
 
     def create_network_interface(self, instance_id: str, subnet_id: str, sg_id: int) -> str:


### PR DESCRIPTION
…ycle.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

On terminate lifecycle of the ASG lambda function invocation `instance_info['SubnetID']` may be undefined. As the parameter is not used in calling `VMSeriesInterfaceScaling.instance_terminate_action`, using ` instance_info.get('SubnetId')` (which return `None` as default) instead of accessing attribute by `[]` operator is an easy fix for that case.

## How Has This Been Tested?

Used the fix to make necessary changes to our own infrastructure after I noticed the failing lambda invocations after ASG terminations.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
