### PR TITLE
fix(module/subnet_set): Added VPC selector to match existing subnets in VPC

### DIFF
--- a/modules/subnet_set/main.tf
+++ b/modules/subnet_set/main.tf
@@ -25,6 +25,7 @@ data "aws_subnet" "this" {
   for_each = { for k, v in local.input_subnets : k => v if v.create_subnet == false }
 
   tags = { Name = each.value.name }
+  vpc_id = var.vpc_id
 }
 
 #### Create Subnets ####

--- a/modules/subnet_set/main.tf
+++ b/modules/subnet_set/main.tf
@@ -24,7 +24,7 @@ locals {
 data "aws_subnet" "this" {
   for_each = { for k, v in local.input_subnets : k => v if v.create_subnet == false }
 
-  tags = { Name = each.value.name }
+  tags   = { Name = each.value.name }
   vpc_id = var.vpc_id
 }
 


### PR DESCRIPTION
## Description

Added a VPC selector to the subnet_set module to avoid problems with identical names of subnets belonging to different VPCs.

## Motivation and Context

If there are multiple subnets in the region that match the selected name, we will get the multiple EC2 subnets matched error: `use additional restrictions to reduce the matches to a single EC2 subnet. `

## How Has This Been Tested?

The check was based on a region where there were about a dozen subnets with the same name. After adding the `vpc_id` parameter, the expected subnet ID was obtained.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
