### PR TITLE
fix(module/bootstrap): Enable ACLs for bucket by setting the object ownership

### DIFF
--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -95,6 +95,7 @@ No modules.
 | [aws_iam_role_policy.bootstrap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_object.bootstrap_dirs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_s3_object.bootstrap_files](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_s3_object.init_cfg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -24,11 +24,22 @@ resource "aws_s3_bucket" "this" {
   tags          = var.global_tags
 }
 
+resource "aws_s3_bucket_ownership_controls" "this" {
+  count  = var.create_bucket == true ? 1 : 0
+  bucket = aws_s3_bucket.this[0].id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 resource "aws_s3_bucket_acl" "this" {
   count = var.create_bucket == true ? 1 : 0
 
   bucket = aws_s3_bucket.this[0].id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.this[0]]
 }
 
 resource "aws_s3_object" "bootstrap_dirs" {


### PR DESCRIPTION
## Description

PR delivers fixes in module `bootstrap` connected with error:

```
Error: error creating S3 bucket ACL for terratest-module-vmseries-8c71f573ee7558e0: AccessControlListNotSupported: The bucket does not allow ACLs
```

## Motivation and Context

Changes in module were required after [Amazon deployed S3 Security Changes in April of 2023 - S3 now automatically enables S3 Block Public Access and disables S3 access control lists (ACLs) for all new S3 buckets in all AWS Regions](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/). 

## How Has This Been Tested?

Code was tested while working on tests for VM-Series in #286 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
