### PR TITLE
feat(workflow): Add workflow for lint PR, fix GitHub release workflow status

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -1,0 +1,21 @@
+# DESCRIPTION:
+#  A workflow used to verify if PR titles matches conventional commits strategy.
+# END
+
+name: Lint PR Title
+run-name: "Lint PR - (#${{ github.event.number }}) ${{ github.event.pull_request.title }}"
+
+permissions:
+  pull-requests: read
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - ready_for_review
+
+jobs:
+  lint_pr_title:
+    name: Lint PR
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/lint_pr_title.yml@v1.2.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/PaloAltoNetworks/terraform-aws-vmseries-modules?style=flat-square)
 ![GitHub](https://img.shields.io/github/license/PaloAltoNetworks/terraform-modules-vmseries-ci-workflows?style=flat-square)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PaloAltoNetworks/terraform-aws-vmseries-modules/release.yml?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/PaloAltoNetworks/terraform-aws-vmseries-modules/release_ci.yml?style=flat-square)
 ![GitHub issues](https://img.shields.io/github/issues/PaloAltoNetworks/terraform-aws-vmseries-modules?style=flat-square)
 ![GitHub pull requests](https://img.shields.io/github/issues-pr/PaloAltoNetworks/terraform-aws-vmseries-modules?style=flat-square)
 ![Terraform registry downloads total](https://img.shields.io/badge/dynamic/json?color=green&label=downloads%20total&query=data.attributes.total&url=https%3A%2F%2Fregistry.terraform.io%2Fv2%2Fmodules%2FPaloAltoNetworks%2Fvmseries-modules%2Faws%2Fdownloads%2Fsummary&style=flat-square)


### PR DESCRIPTION
## Description

Add workflow for lint PR in order to check title (needed to correctly prepare semantic release).
Fix GitHub release workflow status (name of the file with workflow was changed in #328 .

## Motivation and Context

Similar solution we have for [Azure VM-Series modules](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/blob/main/.github/workflows/lint_pr_title.yml), so AWS VM-Series modules needs to be adjusted too.

## How Has This Been Tested?

The same workflow is used for [Azure VM-Series modules](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules/blob/main/.github/workflows/lint_pr_title.yml).

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
