### PR TITLE
fix(module/vpc): Add global tags to network ACL resource

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -125,9 +125,7 @@ resource "aws_network_acl" "this" {
   for_each = var.nacls
   vpc_id   = local.vpc.id
 
-  tags = {
-    Name = each.value.name
-  }
+  tags = merge(var.global_tags, { Name = each.value.name })
 }
 
 locals {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The change updates the tags allocated to the network ACL resource. Currently, all network ACLs created by the VPC module do not contain any shared tags apart from the ACL's name.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The arbitrary tags from `global_tags` variable should be attached to every resource created by the submodule (as stated [in the documentation](https://registry.terraform.io/modules/PaloAltoNetworks/vmseries-modules/aws/latest/submodules/vpc#input_global_tags)), which is currently not the case and introduces inconsistencies in tag allocation. This also makes the network ACLs hard to identify, organize, and filter, as they do not have the expected tags that other resources do.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We've tested the change by modifying the module locally and then re-applying the Terraform plan. All tags from `global_tags` variable were present in the resource.
The `global_tags` variable defaults to an empty map, making the change valid in cases where the tags are not specified at all.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
