### PR TITLE
fix: Resolve IAM issues CKV_AWS_290 and CKV_AWS_355

### DIFF
--- a/examples/centralized_design/README.md
+++ b/examples/centralized_design/README.md
@@ -94,8 +94,10 @@ In example VM-Series are licensed using [Panorama-Based Software Firewall Licens
 | [aws_instance.spoke_vms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs
 

--- a/examples/centralized_design/main.tf
+++ b/examples/centralized_design/main.tf
@@ -303,6 +303,10 @@ locals {
 
 ### IAM ROLES AND POLICIES ###
 
+data "aws_caller_identity" "this" {}
+
+data "aws_partition" "this" {}
+
 resource "aws_iam_role" "vm_series_ec2_iam_role" {
   name               = "${var.name_prefix}vmseries"
   assume_role_policy = <<EOF
@@ -327,15 +331,22 @@ resource "aws_iam_role_policy" "vm_series_ec2_iam_policy" {
   "Statement": [
     {
       "Action": [
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:GetMetricData",
         "cloudwatch:PutMetricData",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:DescribeAlarms",
-        "logs:CreateLogGroup"
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics"
       ],
       "Resource": [
         "*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
       ],
       "Effect": "Allow"
     }

--- a/examples/centralized_design_autoscale/README.md
+++ b/examples/centralized_design_autoscale/README.md
@@ -174,8 +174,10 @@ statistic    = "Maximum"
 | [aws_iam_role_policy.vm_series_ec2_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_instance.spoke_vms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs
 

--- a/examples/centralized_design_autoscale/main.tf
+++ b/examples/centralized_design_autoscale/main.tf
@@ -293,6 +293,10 @@ locals {
 
 ### IAM ROLES AND POLICIES ###
 
+data "aws_caller_identity" "this" {}
+
+data "aws_partition" "this" {}
+
 resource "aws_iam_role" "vm_series_ec2_iam_role" {
   name               = "${var.name_prefix}vmseries"
   assume_role_policy = <<EOF
@@ -317,15 +321,22 @@ resource "aws_iam_role_policy" "vm_series_ec2_iam_policy" {
   "Statement": [
     {
       "Action": [
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:GetMetricData",
         "cloudwatch:PutMetricData",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:DescribeAlarms",
-        "logs:CreateLogGroup"
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics"
       ],
       "Resource": [
         "*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
       ],
       "Effect": "Allow"
     }

--- a/examples/combined_design/README.md
+++ b/examples/combined_design/README.md
@@ -127,8 +127,10 @@ If no errors occurred during deployment, configure the VM-Series machines as exp
 | [aws_instance.spoke_vms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs
 

--- a/examples/combined_design/main.tf
+++ b/examples/combined_design/main.tf
@@ -194,6 +194,10 @@ locals {
 
 ### IAM ROLES AND POLICIES ###
 
+data "aws_caller_identity" "this" {}
+
+data "aws_partition" "this" {}
+
 resource "aws_iam_role" "vm_series_ec2_iam_role" {
   name               = "${var.name_prefix}vmseries"
   assume_role_policy = <<EOF
@@ -218,20 +222,28 @@ resource "aws_iam_role_policy" "vm_series_ec2_iam_policy" {
   "Statement": [
     {
       "Action": [
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:GetMetricData",
         "cloudwatch:PutMetricData",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:DescribeAlarms",
-        "logs:CreateLogGroup"
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics"
       ],
       "Resource": [
         "*"
       ],
       "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
+      ],
+      "Effect": "Allow"
     }
   ]
 }
+
 EOF
 }
 

--- a/examples/combined_design_autoscale/README.md
+++ b/examples/combined_design_autoscale/README.md
@@ -248,8 +248,10 @@ statistic    = "Maximum"
 | [aws_iam_role_policy.vm_series_ec2_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_instance.spoke_vms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs
 

--- a/examples/combined_design_autoscale/main.tf
+++ b/examples/combined_design_autoscale/main.tf
@@ -293,6 +293,10 @@ locals {
 
 ### IAM ROLES AND POLICIES ###
 
+data "aws_caller_identity" "this" {}
+
+data "aws_partition" "this" {}
+
 resource "aws_iam_role" "vm_series_ec2_iam_role" {
   name               = "${var.name_prefix}vmseries"
   assume_role_policy = <<EOF
@@ -317,15 +321,22 @@ resource "aws_iam_role_policy" "vm_series_ec2_iam_policy" {
   "Statement": [
     {
       "Action": [
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:GetMetricData",
         "cloudwatch:PutMetricData",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:DescribeAlarms",
-        "logs:CreateLogGroup"
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics"
       ],
       "Resource": [
         "*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
       ],
       "Effect": "Allow"
     }

--- a/examples/isolated_design/README.md
+++ b/examples/isolated_design/README.md
@@ -95,8 +95,10 @@ In example VM-Series are licensed using [Panorama-Based Software Firewall Licens
 | [aws_lb_target_group_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs
 

--- a/examples/isolated_design/main.tf
+++ b/examples/isolated_design/main.tf
@@ -160,6 +160,10 @@ locals {
 
 ### IAM ROLES AND POLICIES ###
 
+data "aws_caller_identity" "this" {}
+
+data "aws_partition" "this" {}
+
 resource "aws_iam_role" "vm_series_ec2_iam_role" {
   name               = "${var.name_prefix}vmseries"
   assume_role_policy = <<EOF
@@ -184,20 +188,28 @@ resource "aws_iam_role_policy" "vm_series_ec2_iam_policy" {
   "Statement": [
     {
       "Action": [
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:GetMetricData",
         "cloudwatch:PutMetricData",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:DescribeAlarms",
-        "logs:CreateLogGroup"
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics"
       ],
       "Resource": [
         "*"
       ],
       "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
+      ],
+      "Effect": "Allow"
     }
   ]
 }
+
 EOF
 }
 

--- a/examples/isolated_design_autoscale/README.md
+++ b/examples/isolated_design_autoscale/README.md
@@ -204,8 +204,10 @@ statistic    = "Maximum"
 | [aws_instance.spoke_vms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_vpc_peering_connection.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) | resource |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_kms_alias.current_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs
 

--- a/examples/isolated_design_autoscale/main.tf
+++ b/examples/isolated_design_autoscale/main.tf
@@ -150,6 +150,10 @@ locals {
 
 ### IAM ROLES AND POLICIES ###
 
+data "aws_caller_identity" "this" {}
+
+data "aws_partition" "this" {}
+
 resource "aws_iam_role" "vm_series_ec2_iam_role" {
   name               = "${var.name_prefix}vmseries"
   assume_role_policy = <<EOF
@@ -174,15 +178,22 @@ resource "aws_iam_role_policy" "vm_series_ec2_iam_policy" {
   "Statement": [
     {
       "Action": [
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:GetMetricData",
         "cloudwatch:PutMetricData",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:DescribeAlarms",
-        "logs:CreateLogGroup"
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics"
       ],
       "Resource": [
         "*"
+      ],
+      "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
       ],
       "Effect": "Allow"
     }

--- a/examples/panorama_standalone/README.md
+++ b/examples/panorama_standalone/README.md
@@ -85,8 +85,10 @@ Use a web browser to access https://x.x.x.x and login with admin and your previo
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ebs_default_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_kms_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs
 

--- a/examples/panorama_standalone/main.tf
+++ b/examples/panorama_standalone/main.tf
@@ -102,7 +102,7 @@ resource "aws_iam_role_policy" "this" {
             "Action": [
               "ec2:DescribeInstanceStatus",
               "ec2:DescribeInstances"
-            ]
+            ],
             "Resource": "*"
         },
         {
@@ -115,13 +115,13 @@ resource "aws_iam_role_policy" "this" {
             "Resource": "*"
         },
         {
-          "Action": [
-            "cloudwatch:DescribeAlarms"
-          ],
-          "Resource": [
-            "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
-          ],
-          "Effect": "Allow"
+            "Effect": "Allow",
+            "Action": [
+              "cloudwatch:DescribeAlarms"
+            ],
+            "Resource": [
+              "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
+            ]
         }
     ]
 }

--- a/examples/panorama_standalone/main.tf
+++ b/examples/panorama_standalone/main.tf
@@ -64,6 +64,10 @@ module "vpc_routes" {
 
 ### IAM ROLES AND POLICIES ###
 
+data "aws_caller_identity" "this" {}
+
+data "aws_partition" "this" {}
+
 resource "aws_iam_role" "this" {
   for_each           = var.panoramas
   name               = "${var.name_prefix}${each.value.iam.role_name}"
@@ -95,7 +99,10 @@ resource "aws_iam_role_policy" "this" {
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": "ec2:Describe*",
+            "Action": [
+              "ec2:DescribeInstanceStatus",
+              "ec2:DescribeInstances"
+            ]
             "Resource": "*"
         },
         {
@@ -103,9 +110,18 @@ resource "aws_iam_role_policy" "this" {
             "Action": [
                 "cloudwatch:ListMetrics",
                 "cloudwatch:GetMetricStatistics",
-                "cloudwatch:Describe*"
+                "cloudwatch:DescribeAlarmsForMetric"
             ],
             "Resource": "*"
+        },
+        {
+          "Action": [
+            "cloudwatch:DescribeAlarms"
+          ],
+          "Resource": [
+            "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
+          ],
+          "Effect": "Allow"
         }
     ]
 }

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -93,6 +93,8 @@ Use a web browser to access https://x.x.x.x and login with admin and your previo
 | [aws_iam_instance_profile.vm_series_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.vm_series_ec2_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.vm_series_ec2_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ### Inputs
 

--- a/examples/vmseries_standalone/main.tf
+++ b/examples/vmseries_standalone/main.tf
@@ -73,6 +73,10 @@ module "vpc_routes" {
 
 ### IAM ROLES AND POLICIES ###
 
+data "aws_caller_identity" "this" {}
+
+data "aws_partition" "this" {}
+
 resource "aws_iam_role" "vm_series_ec2_iam_role" {
   name               = "${var.name_prefix}vmseries"
   assume_role_policy = <<EOF
@@ -97,20 +101,28 @@ resource "aws_iam_role_policy" "vm_series_ec2_iam_policy" {
   "Statement": [
     {
       "Action": [
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:GetMetricData",
         "cloudwatch:PutMetricData",
-        "cloudwatch:ListMetrics",
-        "cloudwatch:DescribeAlarms",
-        "logs:CreateLogGroup"
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics"
       ],
       "Resource": [
         "*"
       ],
       "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.this.partition}:cloudwatch:${var.region}:${data.aws_caller_identity.this.account_id}:alarm:*"
+      ],
+      "Effect": "Allow"
     }
   ]
 }
+
 EOF
 }
 


### PR DESCRIPTION
## Description

PR resolves IAM issues CKV_AWS_290 and CKV_AWS_355 for examples and in modules.

Almost all actions were reused, but specific resources was added (instead of `*`).
Besides that some of them were removed:
- in all examples for VM-Series role it was removed `logs:CreateLogGroup` as plugin `vmseries` is sending metrics, not logs.
- for module `crosszone_failover` it was removed `logs:*`, because in module there was no reference in the code for CloudWatch logs.

## Motivation and Context

Soft fails from #244 

## How Has This Been Tested?

Code was tested by executing `make test` locally.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
