### PR TITLE
fix(module/subnet_sets): Change default value for nacl_associations variable

### DIFF
--- a/modules/subnet_set/README.md
+++ b/modules/subnet_set/README.md
@@ -68,7 +68,7 @@ No modules.
 | <a name="input_global_tags"></a> [global\_tags](#input\_global\_tags) | Optional map of arbitrary tags to apply to all the created resources. | `map(string)` | `{}` | no |
 | <a name="input_has_secondary_cidrs"></a> [has\_secondary\_cidrs](#input\_has\_secondary\_cidrs) | The input that depends on the secondary CIDR ranges of the VPC `vpc_id`. The actual value (true or false) is ignored, the input is used only to delay subnet creation until the secondary CIDR ranges are processed by Terraform. | `bool` | `true` | no |
 | <a name="input_map_public_ip_on_launch"></a> [map\_public\_ip\_on\_launch](#input\_map\_public\_ip\_on\_launch) | See the [provider's documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet#map_public_ip_on_launch). | `bool` | `null` | no |
-| <a name="input_nacl_associations"></a> [nacl\_associations](#input\_nacl\_associations) | NACLs associations with subnets | `map(string)` | `null` | no |
+| <a name="input_nacl_associations"></a> [nacl\_associations](#input\_nacl\_associations) | NACLs associations with subnets | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | Subnet set name, used to construct default subnet names. | `string` | `null` | no |
 | <a name="input_propagating_vgws"></a> [propagating\_vgws](#input\_propagating\_vgws) | See the [provider's documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table). | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Id of the VPC to create resource in. | `string` | n/a | yes |

--- a/modules/subnet_set/variables.tf
+++ b/modules/subnet_set/variables.tf
@@ -56,6 +56,6 @@ variable "global_tags" {
 
 variable "nacl_associations" {
   description = "NACLs associations with subnets"
-  default     = null
+  default     = {}
   type        = map(string)
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The change sets the default value for the nacl_associations variable from `null` to `{}` (an empty map).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the default null value causes Terraform's plan to fail in case no value for the variable is provided - the module (`aws_network_acl_association` resource) expects `nacl_associations` to be iterable (a map of strings), but when the user does not intend to associate any network ACLs with any subnet and skips the variable altogether, it throws an `Invalid for_each argument` error.
The user has to explicitly set a `nacl_associations` variable to an empty map to avoid errors.
By changing the default value from null to an empty map, the resource creation is skipped without any required workarounds from users.


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The subnet_sets module was deployed without setting any explicit value for `nacl_associations` variable. The plan and apply did not report any errors when the default value was set to an empty map.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->
Error related to the `nacl_associations` being `null`:
![image](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/assets/56642437/634839d3-92f1-41c8-96b3-d96e92d03fb2)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
