### PR TITLE
fix: Add repository as input for all ChatOps commands workflows

### DIFF
--- a/.github/workflows/apply-command.yml
+++ b/.github/workflows/apply-command.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}
@@ -52,5 +52,6 @@ jobs:
       pr-id: ${{ inputs.pr-id }}
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
       cloud: aws
       terratest_action: Apply

--- a/.github/workflows/apply-command.yml
+++ b/.github/workflows/apply-command.yml
@@ -32,6 +32,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   test:

--- a/.github/workflows/apply-command.yml
+++ b/.github/workflows/apply-command.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -34,6 +34,20 @@ jobs:
             console.log(pr.data.head.ref)
             return pr.data.head.ref
 
+      - name: get PR repository
+        uses: actions/github-script@v6
+        id: repo
+        with:
+          result-encoding: string
+          script: |
+            let pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })
+            console.log(pr.data.head.repo.full_name)
+            return pr.data.head.repo.full_name
+
       - name: Generate GitHub token
         id: generate-token
         uses: tibdex/github-app-token@v2
@@ -63,6 +77,7 @@ jobs:
             pr-id=${{ github.event.issue.number }}
             pr-title=${{ github.event.issue.title }}
             branch=${{ steps.pr.outputs.result }}
+            repository=${{ steps.repo.outputs.result }}
 
       - name: Edit comment with error message
         if: steps.scd.outputs.error-message

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -20,6 +20,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   help:

--- a/.github/workflows/idempotence-command.yml
+++ b/.github/workflows/idempotence-command.yml
@@ -32,6 +32,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   test:

--- a/.github/workflows/idempotence-command.yml
+++ b/.github/workflows/idempotence-command.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}
@@ -52,5 +52,6 @@ jobs:
       pr-id: ${{ inputs.pr-id }}
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
       cloud: aws
       terratest_action: Idempotence

--- a/.github/workflows/idempotence-command.yml
+++ b/.github/workflows/idempotence-command.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}

--- a/.github/workflows/plan-command.yml
+++ b/.github/workflows/plan-command.yml
@@ -32,6 +32,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   test:

--- a/.github/workflows/plan-command.yml
+++ b/.github/workflows/plan-command.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}
@@ -52,5 +52,6 @@ jobs:
       pr-id: ${{ inputs.pr-id }}
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
       cloud: aws
       terratest_action: Plan

--- a/.github/workflows/plan-command.yml
+++ b/.github/workflows/plan-command.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}

--- a/.github/workflows/sca-command.yml
+++ b/.github/workflows/sca-command.yml
@@ -23,6 +23,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   init:

--- a/.github/workflows/sca-command.yml
+++ b/.github/workflows/sca-command.yml
@@ -57,11 +57,12 @@ jobs:
     needs: init
     permissions:
       contents: read
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.3
     secrets: inherit
     with:
       pre-commit-hooks: terraform_fmt terraform_docs terraform_tflint checkov
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
 
   finish_comment_pr:
     name: Add a comment to originating PR

--- a/.github/workflows/sca-command.yml
+++ b/.github/workflows/sca-command.yml
@@ -57,7 +57,7 @@ jobs:
     needs: init
     permissions:
       contents: read
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.3
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/_pre_commit.yml@v2.2
     secrets: inherit
     with:
       pre-commit-hooks: terraform_fmt terraform_docs terraform_tflint checkov

--- a/.github/workflows/validate-command.yml
+++ b/.github/workflows/validate-command.yml
@@ -45,7 +45,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@fix-fork-issue
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}

--- a/.github/workflows/validate-command.yml
+++ b/.github/workflows/validate-command.yml
@@ -30,6 +30,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   test:
@@ -41,7 +45,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@fix-fork-issue
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}
@@ -49,5 +53,6 @@ jobs:
       pr-id: ${{ inputs.pr-id }}
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
       cloud: aws
       terratest_action: Validate

--- a/.github/workflows/validate-command.yml
+++ b/.github/workflows/validate-command.yml
@@ -45,7 +45,7 @@ jobs:
       contents: read
       pull-requests: write
       id-token: write
-    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.3
+    uses: PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/.github/workflows/test_command.yml@v2.2
     secrets: inherit
     with:
       paths: ${{ inputs.paths }}


### PR DESCRIPTION
## Description

PR is adding full repository name as input for all ChatOps commands workflows.

## Motivation and Context

While running ChatOps for PR created from forked repository, there is an issue with checkout branch, which exists in fork, not in original repository. Please check error messages in https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/actions/runs/6322173926.

## How Has This Been Tested?

Code was tested by cloning `terraform-aws-vmseries-modules` into personal account, creating fork from that clone and then executing ChatOps commands for PR created from fork.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
