### PR TITLE
fix: Update bitnami-nginx image to 1.25 (1.21 is no more available)

### DIFF
--- a/examples/centralized_design/main.tf
+++ b/examples/centralized_design/main.tf
@@ -184,7 +184,7 @@ data "aws_ami" "this" {
 
   filter {
     name   = "name"
-    values = ["bitnami-nginx-1.21*-linux-debian-10-x86_64-hvm-ebs-nami"]
+    values = ["bitnami-nginx-1.25*-linux-debian-11-x86_64-hvm-ebs-nami"]
     # The wildcard '*' causes re-creation of the whole EC2 instance when a new image appears.
   }
 

--- a/examples/centralized_design_autoscale/main.tf
+++ b/examples/centralized_design_autoscale/main.tf
@@ -174,7 +174,7 @@ data "aws_ami" "this" {
 
   filter {
     name   = "name"
-    values = ["bitnami-nginx-1.21*-linux-debian-10-x86_64-hvm-ebs-nami"]
+    values = ["bitnami-nginx-1.25*-linux-debian-11-x86_64-hvm-ebs-nami"]
     # The wildcard '*' causes re-creation of the whole EC2 instance when a new image appears.
   }
 

--- a/examples/combined_design/main.tf
+++ b/examples/combined_design/main.tf
@@ -290,7 +290,7 @@ data "aws_ami" "this" {
 
   filter {
     name   = "name"
-    values = ["bitnami-nginx-1.21*-linux-debian-10-x86_64-hvm-ebs-nami"]
+    values = ["bitnami-nginx-1.25*-linux-debian-11-x86_64-hvm-ebs-nami"]
     # The wildcard '*' causes re-creation of the whole EC2 instance when a new image appears.
   }
 

--- a/examples/combined_design_autoscale/main.tf
+++ b/examples/combined_design_autoscale/main.tf
@@ -174,7 +174,7 @@ data "aws_ami" "this" {
 
   filter {
     name   = "name"
-    values = ["bitnami-nginx-1.21*-linux-debian-10-x86_64-hvm-ebs-nami"]
+    values = ["bitnami-nginx-1.25*-linux-debian-11-x86_64-hvm-ebs-nami"]
     # The wildcard '*' causes re-creation of the whole EC2 instance when a new image appears.
   }
 

--- a/examples/isolated_design/main.tf
+++ b/examples/isolated_design/main.tf
@@ -256,7 +256,7 @@ data "aws_ami" "this" {
 
   filter {
     name   = "name"
-    values = ["bitnami-nginx-1.21*-linux-debian-10-x86_64-hvm-ebs-nami"]
+    values = ["bitnami-nginx-1.25*-linux-debian-11-x86_64-hvm-ebs-nami"]
     # The wildcard '*' causes re-creation of the whole EC2 instance when a new image appears.
   }
 

--- a/examples/isolated_design_autoscale/main.tf
+++ b/examples/isolated_design_autoscale/main.tf
@@ -255,7 +255,7 @@ data "aws_ami" "this" {
 
   filter {
     name   = "name"
-    values = ["bitnami-nginx-1.21*-linux-debian-10-x86_64-hvm-ebs-nami"]
+    values = ["bitnami-nginx-1.25*-linux-debian-11-x86_64-hvm-ebs-nami"]
     # The wildcard '*' causes re-creation of the whole EC2 instance when a new image appears.
   }
 


### PR DESCRIPTION
## Description

PR updates all examples with spoke VMs with bitnami-nginx image to 1.25.

## Motivation and Context

In all examples there was used bitnami-nginx image in version 1.21, which is no more available. 

## How Has This Been Tested?

Code was checked locally and on GitHub Actions.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
