### PR TITLE
fix: One more HTML tag removed from README

### DIFF
--- a/examples/isolated_design_autoscale/README.md
+++ b/examples/isolated_design_autoscale/README.md
@@ -68,7 +68,6 @@ Below there is shown example of VR configuration with static routes and path mon
 | app2_az2 | 10.105.0.0/16 | 10.100.65.1 | 12 | 10.100.65.1 |
 | health_az1 | 10.100.0.0/16 | 10.100.1.1 | 11 | 10.100.1.1 |
 | health_az2 | 10.100.0.0/16 | 10.100.65.1 | 12 | 10.100.65.1 |
-</p>
 
 An example XML configuration snippet (for PANOS 10.2.3) of the described configuration can be found [here](template-asg-path-monitoring.xml), which after importing to Panorama, can be merged using the command:
 


### PR DESCRIPTION
## Description

PR removes HTML tags `p` from README

## Motivation and Context

Changes were connected with automatic generation of documentation in pan.dev

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
