### PR TITLE
fix(examples): Change region for examples from eu-central-1 to eu-west-1

### DIFF
--- a/examples/centralized_design/example.tfvars
+++ b/examples/centralized_design/example.tfvars
@@ -1,5 +1,5 @@
 ### General
-region      = "eu-central-1" # TODO: update here
+region      = "eu-west-1" # TODO: update here
 name_prefix = "example-"     # TODO: update here
 
 global_tags = {
@@ -187,24 +187,24 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf
-      "10.100.0.0/24"  = { az = "eu-central-1a", set = "mgmt", nacl = null }
-      "10.100.64.0/24" = { az = "eu-central-1b", set = "mgmt", nacl = null }
-      "10.100.1.0/24"  = { az = "eu-central-1a", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.65.0/24" = { az = "eu-central-1b", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.2.0/24"  = { az = "eu-central-1a", set = "public", nacl = null }
-      "10.100.66.0/24" = { az = "eu-central-1b", set = "public", nacl = null }
-      "10.100.3.0/24"  = { az = "eu-central-1a", set = "tgw_attach", nacl = null }
-      "10.100.67.0/24" = { az = "eu-central-1b", set = "tgw_attach", nacl = null }
-      "10.100.4.0/24"  = { az = "eu-central-1a", set = "gwlbe_outbound", nacl = null }
-      "10.100.68.0/24" = { az = "eu-central-1b", set = "gwlbe_outbound", nacl = null }
-      "10.100.5.0/24"  = { az = "eu-central-1a", set = "gwlb", nacl = null }
-      "10.100.69.0/24" = { az = "eu-central-1b", set = "gwlb", nacl = null } # AWS reccomends to always go up to the last possible AZ for GWLB service
-      "10.100.10.0/24" = { az = "eu-central-1a", set = "gwlbe_eastwest", nacl = null }
-      "10.100.74.0/24" = { az = "eu-central-1b", set = "gwlbe_eastwest", nacl = null }
-      "10.100.6.0/24"  = { az = "eu-central-1a", set = "alb", nacl = null }
-      "10.100.70.0/24" = { az = "eu-central-1b", set = "alb", nacl = null }
-      "10.100.7.0/24"  = { az = "eu-central-1a", set = "nlb", nacl = null }
-      "10.100.71.0/24" = { az = "eu-central-1b", set = "nlb", nacl = null }
+      "10.100.0.0/24"  = { az = "eu-west-1a", set = "mgmt", nacl = null }
+      "10.100.64.0/24" = { az = "eu-west-1b", set = "mgmt", nacl = null }
+      "10.100.1.0/24"  = { az = "eu-west-1a", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.65.0/24" = { az = "eu-west-1b", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.2.0/24"  = { az = "eu-west-1a", set = "public", nacl = null }
+      "10.100.66.0/24" = { az = "eu-west-1b", set = "public", nacl = null }
+      "10.100.3.0/24"  = { az = "eu-west-1a", set = "tgw_attach", nacl = null }
+      "10.100.67.0/24" = { az = "eu-west-1b", set = "tgw_attach", nacl = null }
+      "10.100.4.0/24"  = { az = "eu-west-1a", set = "gwlbe_outbound", nacl = null }
+      "10.100.68.0/24" = { az = "eu-west-1b", set = "gwlbe_outbound", nacl = null }
+      "10.100.5.0/24"  = { az = "eu-west-1a", set = "gwlb", nacl = null }
+      "10.100.69.0/24" = { az = "eu-west-1b", set = "gwlb", nacl = null } # AWS reccomends to always go up to the last possible AZ for GWLB service
+      "10.100.10.0/24" = { az = "eu-west-1a", set = "gwlbe_eastwest", nacl = null }
+      "10.100.74.0/24" = { az = "eu-west-1b", set = "gwlbe_eastwest", nacl = null }
+      "10.100.6.0/24"  = { az = "eu-west-1a", set = "alb", nacl = null }
+      "10.100.70.0/24" = { az = "eu-west-1b", set = "alb", nacl = null }
+      "10.100.7.0/24"  = { az = "eu-west-1a", set = "nlb", nacl = null }
+      "10.100.71.0/24" = { az = "eu-west-1b", set = "nlb", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -322,10 +322,10 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.104.0.0/24"   = { az = "eu-central-1a", set = "app1_vm", nacl = null }
-      "10.104.128.0/24" = { az = "eu-central-1b", set = "app1_vm", nacl = null }
-      "10.104.2.0/24"   = { az = "eu-central-1a", set = "app1_lb", nacl = null }
-      "10.104.130.0/24" = { az = "eu-central-1b", set = "app1_lb", nacl = null }
+      "10.104.0.0/24"   = { az = "eu-west-1a", set = "app1_vm", nacl = null }
+      "10.104.128.0/24" = { az = "eu-west-1b", set = "app1_vm", nacl = null }
+      "10.104.2.0/24"   = { az = "eu-west-1a", set = "app1_lb", nacl = null }
+      "10.104.130.0/24" = { az = "eu-west-1b", set = "app1_lb", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -383,10 +383,10 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.105.0.0/24"   = { az = "eu-central-1a", set = "app2_vm", nacl = null }
-      "10.105.128.0/24" = { az = "eu-central-1b", set = "app2_vm", nacl = null }
-      "10.105.2.0/24"   = { az = "eu-central-1a", set = "app2_lb", nacl = null }
-      "10.105.130.0/24" = { az = "eu-central-1b", set = "app2_lb", nacl = null }
+      "10.105.0.0/24"   = { az = "eu-west-1a", set = "app2_vm", nacl = null }
+      "10.105.128.0/24" = { az = "eu-west-1b", set = "app2_vm", nacl = null }
+      "10.105.2.0/24"   = { az = "eu-west-1a", set = "app2_lb", nacl = null }
+      "10.105.130.0/24" = { az = "eu-west-1b", set = "app2_lb", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -486,8 +486,8 @@ gwlb_endpoints = {
 vmseries = {
   vmseries = {
     instances = {
-      "01" = { az = "eu-central-1a" }
-      "02" = { az = "eu-central-1b" }
+      "01" = { az = "eu-west-1a" }
+      "02" = { az = "eu-west-1b" }
     }
 
     # Value of `panorama-server`, `auth-key`, `dgname`, `tplname` can be taken from plugin `sw_fw_license`
@@ -625,28 +625,28 @@ panorama_attachment = {
 ### SPOKE VMS
 spoke_vms = {
   "app1_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app1_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app2_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"
     type           = "t2.micro"
   }
   "app2_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"

--- a/examples/centralized_design/example.tfvars
+++ b/examples/centralized_design/example.tfvars
@@ -1,6 +1,6 @@
 ### General
 region      = "eu-west-1" # TODO: update here
-name_prefix = "example-"     # TODO: update here
+name_prefix = "example-"  # TODO: update here
 
 global_tags = {
   ManagedBy   = "terraform"

--- a/examples/centralized_design_autoscale/example.tfvars
+++ b/examples/centralized_design_autoscale/example.tfvars
@@ -1,6 +1,6 @@
 ### General
 region      = "eu-west-1" # TODO: update here
-name_prefix = "example-"     # TODO: update here
+name_prefix = "example-"  # TODO: update here
 
 global_tags = {
   ManagedBy   = "terraform"

--- a/examples/centralized_design_autoscale/example.tfvars
+++ b/examples/centralized_design_autoscale/example.tfvars
@@ -1,5 +1,5 @@
 ### General
-region      = "eu-central-1" # TODO: update here
+region      = "eu-west-1" # TODO: update here
 name_prefix = "example-"     # TODO: update here
 
 global_tags = {
@@ -187,24 +187,24 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf
-      "10.100.0.0/24"  = { az = "eu-central-1a", set = "mgmt", nacl = null }
-      "10.100.64.0/24" = { az = "eu-central-1b", set = "mgmt", nacl = null }
-      "10.100.1.0/24"  = { az = "eu-central-1a", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.65.0/24" = { az = "eu-central-1b", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.2.0/24"  = { az = "eu-central-1a", set = "public", nacl = null }
-      "10.100.66.0/24" = { az = "eu-central-1b", set = "public", nacl = null }
-      "10.100.3.0/24"  = { az = "eu-central-1a", set = "tgw_attach", nacl = null }
-      "10.100.67.0/24" = { az = "eu-central-1b", set = "tgw_attach", nacl = null }
-      "10.100.4.0/24"  = { az = "eu-central-1a", set = "gwlbe_outbound", nacl = null }
-      "10.100.68.0/24" = { az = "eu-central-1b", set = "gwlbe_outbound", nacl = null }
-      "10.100.5.0/24"  = { az = "eu-central-1a", set = "gwlb", nacl = null }
-      "10.100.69.0/24" = { az = "eu-central-1b", set = "gwlb", nacl = null } # AWS reccomends to always go up to the last possible AZ for GWLB service
-      "10.100.10.0/24" = { az = "eu-central-1a", set = "gwlbe_eastwest", nacl = null }
-      "10.100.74.0/24" = { az = "eu-central-1b", set = "gwlbe_eastwest", nacl = null }
-      "10.100.6.0/24"  = { az = "eu-central-1a", set = "alb", nacl = null }
-      "10.100.70.0/24" = { az = "eu-central-1b", set = "alb", nacl = null }
-      "10.100.7.0/24"  = { az = "eu-central-1a", set = "nlb", nacl = null }
-      "10.100.71.0/24" = { az = "eu-central-1b", set = "nlb", nacl = null }
+      "10.100.0.0/24"  = { az = "eu-west-1a", set = "mgmt", nacl = null }
+      "10.100.64.0/24" = { az = "eu-west-1b", set = "mgmt", nacl = null }
+      "10.100.1.0/24"  = { az = "eu-west-1a", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.65.0/24" = { az = "eu-west-1b", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.2.0/24"  = { az = "eu-west-1a", set = "public", nacl = null }
+      "10.100.66.0/24" = { az = "eu-west-1b", set = "public", nacl = null }
+      "10.100.3.0/24"  = { az = "eu-west-1a", set = "tgw_attach", nacl = null }
+      "10.100.67.0/24" = { az = "eu-west-1b", set = "tgw_attach", nacl = null }
+      "10.100.4.0/24"  = { az = "eu-west-1a", set = "gwlbe_outbound", nacl = null }
+      "10.100.68.0/24" = { az = "eu-west-1b", set = "gwlbe_outbound", nacl = null }
+      "10.100.5.0/24"  = { az = "eu-west-1a", set = "gwlb", nacl = null }
+      "10.100.69.0/24" = { az = "eu-west-1b", set = "gwlb", nacl = null } # AWS reccomends to always go up to the last possible AZ for GWLB service
+      "10.100.10.0/24" = { az = "eu-west-1a", set = "gwlbe_eastwest", nacl = null }
+      "10.100.74.0/24" = { az = "eu-west-1b", set = "gwlbe_eastwest", nacl = null }
+      "10.100.6.0/24"  = { az = "eu-west-1a", set = "alb", nacl = null }
+      "10.100.70.0/24" = { az = "eu-west-1b", set = "alb", nacl = null }
+      "10.100.7.0/24"  = { az = "eu-west-1a", set = "nlb", nacl = null }
+      "10.100.71.0/24" = { az = "eu-west-1b", set = "nlb", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -322,10 +322,10 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.104.0.0/24"   = { az = "eu-central-1a", set = "app1_vm", nacl = null }
-      "10.104.128.0/24" = { az = "eu-central-1b", set = "app1_vm", nacl = null }
-      "10.104.2.0/24"   = { az = "eu-central-1a", set = "app1_lb", nacl = null }
-      "10.104.130.0/24" = { az = "eu-central-1b", set = "app1_lb", nacl = null }
+      "10.104.0.0/24"   = { az = "eu-west-1a", set = "app1_vm", nacl = null }
+      "10.104.128.0/24" = { az = "eu-west-1b", set = "app1_vm", nacl = null }
+      "10.104.2.0/24"   = { az = "eu-west-1a", set = "app1_lb", nacl = null }
+      "10.104.130.0/24" = { az = "eu-west-1b", set = "app1_lb", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -383,10 +383,10 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.105.0.0/24"   = { az = "eu-central-1a", set = "app2_vm", nacl = null }
-      "10.105.128.0/24" = { az = "eu-central-1b", set = "app2_vm", nacl = null }
-      "10.105.2.0/24"   = { az = "eu-central-1a", set = "app2_lb", nacl = null }
-      "10.105.130.0/24" = { az = "eu-central-1b", set = "app2_lb", nacl = null }
+      "10.105.0.0/24"   = { az = "eu-west-1a", set = "app2_vm", nacl = null }
+      "10.105.128.0/24" = { az = "eu-west-1b", set = "app2_vm", nacl = null }
+      "10.105.2.0/24"   = { az = "eu-west-1a", set = "app2_lb", nacl = null }
+      "10.105.130.0/24" = { az = "eu-west-1b", set = "app2_lb", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -513,8 +513,8 @@ vmseries_asgs = {
         device_index   = 0
         security_group = "vmseries_private"
         subnet = {
-          "privatea" = "eu-central-1a",
-          "privateb" = "eu-central-1b"
+          "privatea" = "eu-west-1a",
+          "privateb" = "eu-west-1b"
         }
         create_public_ip  = false
         source_dest_check = false
@@ -523,8 +523,8 @@ vmseries_asgs = {
         device_index   = 1
         security_group = "vmseries_mgmt"
         subnet = {
-          "mgmta" = "eu-central-1a",
-          "mgmtb" = "eu-central-1b"
+          "mgmta" = "eu-west-1a",
+          "mgmtb" = "eu-west-1b"
         }
         create_public_ip  = true
         source_dest_check = true
@@ -533,8 +533,8 @@ vmseries_asgs = {
         device_index   = 2
         security_group = "vmseries_public"
         subnet = {
-          "publica" = "eu-central-1a",
-          "publicb" = "eu-central-1b"
+          "publica" = "eu-west-1a",
+          "publicb" = "eu-west-1b"
         }
         create_public_ip  = true
         source_dest_check = false
@@ -639,28 +639,28 @@ panorama_attachment = {
 ### SPOKE VMS
 spoke_vms = {
   "app1_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app1_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app2_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"
     type           = "t2.micro"
   }
   "app2_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"

--- a/examples/combined_design/example.tfvars
+++ b/examples/combined_design/example.tfvars
@@ -1,5 +1,5 @@
 ### GENERAL
-region      = "eu-central-1" # TODO: update here
+region      = "eu-west-1" # TODO: update here
 name_prefix = "example-"     # TODO: update here
 
 global_tags = {
@@ -148,20 +148,20 @@ vpcs = {
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf
       # Value of `nacl` must match key of objects stored in `nacls`
-      "10.100.0.0/24"  = { az = "eu-central-1a", set = "mgmt", nacl = null }
-      "10.100.64.0/24" = { az = "eu-central-1b", set = "mgmt", nacl = null }
-      "10.100.1.0/24"  = { az = "eu-central-1a", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.65.0/24" = { az = "eu-central-1b", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.2.0/24"  = { az = "eu-central-1a", set = "public", nacl = null }
-      "10.100.66.0/24" = { az = "eu-central-1b", set = "public", nacl = null }
-      "10.100.3.0/24"  = { az = "eu-central-1a", set = "tgw_attach", nacl = null }
-      "10.100.67.0/24" = { az = "eu-central-1b", set = "tgw_attach", nacl = null }
-      "10.100.4.0/24"  = { az = "eu-central-1a", set = "gwlbe_outbound", nacl = null }
-      "10.100.68.0/24" = { az = "eu-central-1b", set = "gwlbe_outbound", nacl = null }
-      "10.100.5.0/24"  = { az = "eu-central-1a", set = "gwlb", nacl = null }
-      "10.100.69.0/24" = { az = "eu-central-1b", set = "gwlb", nacl = null }
-      "10.100.10.0/24" = { az = "eu-central-1a", set = "gwlbe_eastwest", nacl = null }
-      "10.100.74.0/24" = { az = "eu-central-1b", set = "gwlbe_eastwest", nacl = null }
+      "10.100.0.0/24"  = { az = "eu-west-1a", set = "mgmt", nacl = null }
+      "10.100.64.0/24" = { az = "eu-west-1b", set = "mgmt", nacl = null }
+      "10.100.1.0/24"  = { az = "eu-west-1a", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.65.0/24" = { az = "eu-west-1b", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.2.0/24"  = { az = "eu-west-1a", set = "public", nacl = null }
+      "10.100.66.0/24" = { az = "eu-west-1b", set = "public", nacl = null }
+      "10.100.3.0/24"  = { az = "eu-west-1a", set = "tgw_attach", nacl = null }
+      "10.100.67.0/24" = { az = "eu-west-1b", set = "tgw_attach", nacl = null }
+      "10.100.4.0/24"  = { az = "eu-west-1a", set = "gwlbe_outbound", nacl = null }
+      "10.100.68.0/24" = { az = "eu-west-1b", set = "gwlbe_outbound", nacl = null }
+      "10.100.5.0/24"  = { az = "eu-west-1a", set = "gwlb", nacl = null }
+      "10.100.69.0/24" = { az = "eu-west-1b", set = "gwlb", nacl = null }
+      "10.100.10.0/24" = { az = "eu-west-1a", set = "gwlbe_eastwest", nacl = null }
+      "10.100.74.0/24" = { az = "eu-west-1b", set = "gwlbe_eastwest", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -270,12 +270,12 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.104.0.0/24"   = { az = "eu-central-1a", set = "app1_vm", nacl = null }
-      "10.104.128.0/24" = { az = "eu-central-1b", set = "app1_vm", nacl = null }
-      "10.104.2.0/24"   = { az = "eu-central-1a", set = "app1_lb", nacl = null }
-      "10.104.130.0/24" = { az = "eu-central-1b", set = "app1_lb", nacl = null }
-      "10.104.3.0/24"   = { az = "eu-central-1a", set = "app1_gwlbe", nacl = null }
-      "10.104.131.0/24" = { az = "eu-central-1b", set = "app1_gwlbe", nacl = null }
+      "10.104.0.0/24"   = { az = "eu-west-1a", set = "app1_vm", nacl = null }
+      "10.104.128.0/24" = { az = "eu-west-1b", set = "app1_vm", nacl = null }
+      "10.104.2.0/24"   = { az = "eu-west-1a", set = "app1_lb", nacl = null }
+      "10.104.130.0/24" = { az = "eu-west-1b", set = "app1_lb", nacl = null }
+      "10.104.3.0/24"   = { az = "eu-west-1a", set = "app1_gwlbe", nacl = null }
+      "10.104.131.0/24" = { az = "eu-west-1b", set = "app1_gwlbe", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -354,12 +354,12 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.105.0.0/24"   = { az = "eu-central-1a", set = "app2_vm", nacl = null }
-      "10.105.128.0/24" = { az = "eu-central-1b", set = "app2_vm", nacl = null }
-      "10.105.2.0/24"   = { az = "eu-central-1a", set = "app2_lb", nacl = null }
-      "10.105.130.0/24" = { az = "eu-central-1b", set = "app2_lb", nacl = null }
-      "10.105.3.0/24"   = { az = "eu-central-1a", set = "app2_gwlbe", nacl = null }
-      "10.105.131.0/24" = { az = "eu-central-1b", set = "app2_gwlbe", nacl = null }
+      "10.105.0.0/24"   = { az = "eu-west-1a", set = "app2_vm", nacl = null }
+      "10.105.128.0/24" = { az = "eu-west-1b", set = "app2_vm", nacl = null }
+      "10.105.2.0/24"   = { az = "eu-west-1a", set = "app2_lb", nacl = null }
+      "10.105.130.0/24" = { az = "eu-west-1b", set = "app2_lb", nacl = null }
+      "10.105.3.0/24"   = { az = "eu-west-1a", set = "app2_gwlbe", nacl = null }
+      "10.105.131.0/24" = { az = "eu-west-1b", set = "app2_gwlbe", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -481,8 +481,8 @@ gwlb_endpoints = {
 vmseries = {
   vmseries = {
     instances = {
-      "01" = { az = "eu-central-1a" }
-      "02" = { az = "eu-central-1b" }
+      "01" = { az = "eu-west-1a" }
+      "02" = { az = "eu-west-1b" }
     }
 
     # Value of `panorama-server`, `auth-key`, `dgname`, `tplname` can be taken from plugin `sw_fw_license`
@@ -585,28 +585,28 @@ panorama_attachment = {
 ### SPOKE VMS
 spoke_vms = {
   "app1_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app1_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app2_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"
     type           = "t2.micro"
   }
   "app2_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"

--- a/examples/combined_design/example.tfvars
+++ b/examples/combined_design/example.tfvars
@@ -1,6 +1,6 @@
 ### GENERAL
 region      = "eu-west-1" # TODO: update here
-name_prefix = "example-"     # TODO: update here
+name_prefix = "example-"  # TODO: update here
 
 global_tags = {
   ManagedBy   = "terraform"

--- a/examples/combined_design_autoscale/example.tfvars
+++ b/examples/combined_design_autoscale/example.tfvars
@@ -1,5 +1,5 @@
 ### GENERAL
-region      = "eu-central-1" # TODO: update here
+region      = "eu-west-1" # TODO: update here
 name_prefix = "example-"     # TODO: update here
 
 global_tags = {
@@ -148,20 +148,20 @@ vpcs = {
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf
       # Value of `nacl` must match key of objects stored in `nacls`
-      "10.100.0.0/24"  = { az = "eu-central-1a", set = "mgmt", nacl = null }
-      "10.100.64.0/24" = { az = "eu-central-1b", set = "mgmt", nacl = null }
-      "10.100.1.0/24"  = { az = "eu-central-1a", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.65.0/24" = { az = "eu-central-1b", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.2.0/24"  = { az = "eu-central-1a", set = "public", nacl = null }
-      "10.100.66.0/24" = { az = "eu-central-1b", set = "public", nacl = null }
-      "10.100.3.0/24"  = { az = "eu-central-1a", set = "tgw_attach", nacl = null }
-      "10.100.67.0/24" = { az = "eu-central-1b", set = "tgw_attach", nacl = null }
-      "10.100.4.0/24"  = { az = "eu-central-1a", set = "gwlbe_outbound", nacl = null }
-      "10.100.68.0/24" = { az = "eu-central-1b", set = "gwlbe_outbound", nacl = null }
-      "10.100.5.0/24"  = { az = "eu-central-1a", set = "gwlb", nacl = null }
-      "10.100.69.0/24" = { az = "eu-central-1b", set = "gwlb", nacl = null }
-      "10.100.10.0/24" = { az = "eu-central-1a", set = "gwlbe_eastwest", nacl = null }
-      "10.100.74.0/24" = { az = "eu-central-1b", set = "gwlbe_eastwest", nacl = null }
+      "10.100.0.0/24"  = { az = "eu-west-1a", set = "mgmt", nacl = null }
+      "10.100.64.0/24" = { az = "eu-west-1b", set = "mgmt", nacl = null }
+      "10.100.1.0/24"  = { az = "eu-west-1a", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.65.0/24" = { az = "eu-west-1b", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.2.0/24"  = { az = "eu-west-1a", set = "public", nacl = null }
+      "10.100.66.0/24" = { az = "eu-west-1b", set = "public", nacl = null }
+      "10.100.3.0/24"  = { az = "eu-west-1a", set = "tgw_attach", nacl = null }
+      "10.100.67.0/24" = { az = "eu-west-1b", set = "tgw_attach", nacl = null }
+      "10.100.4.0/24"  = { az = "eu-west-1a", set = "gwlbe_outbound", nacl = null }
+      "10.100.68.0/24" = { az = "eu-west-1b", set = "gwlbe_outbound", nacl = null }
+      "10.100.5.0/24"  = { az = "eu-west-1a", set = "gwlb", nacl = null }
+      "10.100.69.0/24" = { az = "eu-west-1b", set = "gwlb", nacl = null }
+      "10.100.10.0/24" = { az = "eu-west-1a", set = "gwlbe_eastwest", nacl = null }
+      "10.100.74.0/24" = { az = "eu-west-1b", set = "gwlbe_eastwest", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -250,12 +250,12 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.104.0.0/24"   = { az = "eu-central-1a", set = "app1_vm", nacl = null }
-      "10.104.128.0/24" = { az = "eu-central-1b", set = "app1_vm", nacl = null }
-      "10.104.2.0/24"   = { az = "eu-central-1a", set = "app1_lb", nacl = null }
-      "10.104.130.0/24" = { az = "eu-central-1b", set = "app1_lb", nacl = null }
-      "10.104.3.0/24"   = { az = "eu-central-1a", set = "app1_gwlbe", nacl = null }
-      "10.104.131.0/24" = { az = "eu-central-1b", set = "app1_gwlbe", nacl = null }
+      "10.104.0.0/24"   = { az = "eu-west-1a", set = "app1_vm", nacl = null }
+      "10.104.128.0/24" = { az = "eu-west-1b", set = "app1_vm", nacl = null }
+      "10.104.2.0/24"   = { az = "eu-west-1a", set = "app1_lb", nacl = null }
+      "10.104.130.0/24" = { az = "eu-west-1b", set = "app1_lb", nacl = null }
+      "10.104.3.0/24"   = { az = "eu-west-1a", set = "app1_gwlbe", nacl = null }
+      "10.104.131.0/24" = { az = "eu-west-1b", set = "app1_gwlbe", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -314,12 +314,12 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.105.0.0/24"   = { az = "eu-central-1a", set = "app2_vm", nacl = null }
-      "10.105.128.0/24" = { az = "eu-central-1b", set = "app2_vm", nacl = null }
-      "10.105.2.0/24"   = { az = "eu-central-1a", set = "app2_lb", nacl = null }
-      "10.105.130.0/24" = { az = "eu-central-1b", set = "app2_lb", nacl = null }
-      "10.105.3.0/24"   = { az = "eu-central-1a", set = "app2_gwlbe", nacl = null }
-      "10.105.131.0/24" = { az = "eu-central-1b", set = "app2_gwlbe", nacl = null }
+      "10.105.0.0/24"   = { az = "eu-west-1a", set = "app2_vm", nacl = null }
+      "10.105.128.0/24" = { az = "eu-west-1b", set = "app2_vm", nacl = null }
+      "10.105.2.0/24"   = { az = "eu-west-1a", set = "app2_lb", nacl = null }
+      "10.105.130.0/24" = { az = "eu-west-1b", set = "app2_lb", nacl = null }
+      "10.105.3.0/24"   = { az = "eu-west-1a", set = "app2_gwlbe", nacl = null }
+      "10.105.131.0/24" = { az = "eu-west-1b", set = "app2_gwlbe", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -468,8 +468,8 @@ vmseries_asgs = {
         device_index   = 0
         security_group = "vmseries_private"
         subnet = {
-          "privatea" = "eu-central-1a",
-          "privateb" = "eu-central-1b"
+          "privatea" = "eu-west-1a",
+          "privateb" = "eu-west-1b"
         }
         create_public_ip  = false
         source_dest_check = false
@@ -478,8 +478,8 @@ vmseries_asgs = {
         device_index   = 1
         security_group = "vmseries_mgmt"
         subnet = {
-          "mgmta" = "eu-central-1a",
-          "mgmtb" = "eu-central-1b"
+          "mgmta" = "eu-west-1a",
+          "mgmtb" = "eu-west-1b"
         }
         create_public_ip  = true
         source_dest_check = true
@@ -488,8 +488,8 @@ vmseries_asgs = {
         device_index   = 2
         security_group = "vmseries_public"
         subnet = {
-          "publica" = "eu-central-1a",
-          "publicb" = "eu-central-1b"
+          "publica" = "eu-west-1a",
+          "publicb" = "eu-west-1b"
         }
         create_public_ip  = true
         source_dest_check = false
@@ -555,28 +555,28 @@ panorama_attachment = {
 ### SPOKE VMS
 spoke_vms = {
   "app1_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app1_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app2_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"
     type           = "t2.micro"
   }
   "app2_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"

--- a/examples/combined_design_autoscale/example.tfvars
+++ b/examples/combined_design_autoscale/example.tfvars
@@ -1,6 +1,6 @@
 ### GENERAL
 region      = "eu-west-1" # TODO: update here
-name_prefix = "example-"     # TODO: update here
+name_prefix = "example-"  # TODO: update here
 
 global_tags = {
   ManagedBy   = "terraform"

--- a/examples/isolated_design/example.tfvars
+++ b/examples/isolated_design/example.tfvars
@@ -1,5 +1,5 @@
 ### GENERAL
-region      = "eu-central-1" # TODO: update here
+region      = "eu-west-1" # TODO: update here
 name_prefix = "example-"     # TODO: update here
 
 global_tags = {
@@ -148,14 +148,14 @@ vpcs = {
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf
       # Value of `nacl` must match key of objects stored in `nacls`
-      "10.100.0.0/24"  = { az = "eu-central-1a", set = "mgmt", nacl = null }
-      "10.100.64.0/24" = { az = "eu-central-1b", set = "mgmt", nacl = null }
-      "10.100.1.0/24"  = { az = "eu-central-1a", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.65.0/24" = { az = "eu-central-1b", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.2.0/24"  = { az = "eu-central-1a", set = "public", nacl = null }
-      "10.100.66.0/24" = { az = "eu-central-1b", set = "public", nacl = null }
-      "10.100.5.0/24"  = { az = "eu-central-1a", set = "gwlb", nacl = null }
-      "10.100.69.0/24" = { az = "eu-central-1b", set = "gwlb", nacl = null }
+      "10.100.0.0/24"  = { az = "eu-west-1a", set = "mgmt", nacl = null }
+      "10.100.64.0/24" = { az = "eu-west-1b", set = "mgmt", nacl = null }
+      "10.100.1.0/24"  = { az = "eu-west-1a", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.65.0/24" = { az = "eu-west-1b", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.2.0/24"  = { az = "eu-west-1a", set = "public", nacl = null }
+      "10.100.66.0/24" = { az = "eu-west-1b", set = "public", nacl = null }
+      "10.100.5.0/24"  = { az = "eu-west-1a", set = "gwlb", nacl = null }
+      "10.100.69.0/24" = { az = "eu-west-1b", set = "gwlb", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -234,12 +234,12 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.104.0.0/24"   = { az = "eu-central-1a", set = "app1_vm", nacl = null }
-      "10.104.128.0/24" = { az = "eu-central-1b", set = "app1_vm", nacl = null }
-      "10.104.2.0/24"   = { az = "eu-central-1a", set = "app1_lb", nacl = null }
-      "10.104.130.0/24" = { az = "eu-central-1b", set = "app1_lb", nacl = null }
-      "10.104.3.0/24"   = { az = "eu-central-1a", set = "app1_gwlbe", nacl = null }
-      "10.104.131.0/24" = { az = "eu-central-1b", set = "app1_gwlbe", nacl = null }
+      "10.104.0.0/24"   = { az = "eu-west-1a", set = "app1_vm", nacl = null }
+      "10.104.128.0/24" = { az = "eu-west-1b", set = "app1_vm", nacl = null }
+      "10.104.2.0/24"   = { az = "eu-west-1a", set = "app1_lb", nacl = null }
+      "10.104.130.0/24" = { az = "eu-west-1b", set = "app1_lb", nacl = null }
+      "10.104.3.0/24"   = { az = "eu-west-1a", set = "app1_gwlbe", nacl = null }
+      "10.104.131.0/24" = { az = "eu-west-1b", set = "app1_gwlbe", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -318,12 +318,12 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.105.0.0/24"   = { az = "eu-central-1a", set = "app2_vm", nacl = null }
-      "10.105.128.0/24" = { az = "eu-central-1b", set = "app2_vm", nacl = null }
-      "10.105.2.0/24"   = { az = "eu-central-1a", set = "app2_lb", nacl = null }
-      "10.105.130.0/24" = { az = "eu-central-1b", set = "app2_lb", nacl = null }
-      "10.105.3.0/24"   = { az = "eu-central-1a", set = "app2_gwlbe", nacl = null }
-      "10.105.131.0/24" = { az = "eu-central-1b", set = "app2_gwlbe", nacl = null }
+      "10.105.0.0/24"   = { az = "eu-west-1a", set = "app2_vm", nacl = null }
+      "10.105.128.0/24" = { az = "eu-west-1b", set = "app2_vm", nacl = null }
+      "10.105.2.0/24"   = { az = "eu-west-1a", set = "app2_lb", nacl = null }
+      "10.105.130.0/24" = { az = "eu-west-1b", set = "app2_lb", nacl = null }
+      "10.105.3.0/24"   = { az = "eu-west-1a", set = "app2_gwlbe", nacl = null }
+      "10.105.131.0/24" = { az = "eu-west-1b", set = "app2_gwlbe", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -385,8 +385,8 @@ gwlb_endpoints = {
 vmseries = {
   vmseries = {
     instances = {
-      "01" = { az = "eu-central-1a" }
-      "02" = { az = "eu-central-1b" }
+      "01" = { az = "eu-west-1a" }
+      "02" = { az = "eu-west-1b" }
     }
 
     # Value of `panorama-server`, `auth-key`, `dgname`, `tplname` can be taken from plugin `sw_fw_license`
@@ -480,28 +480,28 @@ panorama_connection = {
 ### SPOKE VMS
 spoke_vms = {
   "app1_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app1_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app2_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"
     type           = "t2.micro"
   }
   "app2_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"

--- a/examples/isolated_design/example.tfvars
+++ b/examples/isolated_design/example.tfvars
@@ -1,6 +1,6 @@
 ### GENERAL
 region      = "eu-west-1" # TODO: update here
-name_prefix = "example-"     # TODO: update here
+name_prefix = "example-"  # TODO: update here
 
 global_tags = {
   ManagedBy   = "terraform"

--- a/examples/isolated_design_autoscale/example.tfvars
+++ b/examples/isolated_design_autoscale/example.tfvars
@@ -1,5 +1,5 @@
 ### GENERAL
-region      = "eu-central-1" # TODO: update here
+region      = "eu-west-1" # TODO: update here
 name_prefix = "example-"     # TODO: update here
 
 global_tags = {
@@ -148,14 +148,14 @@ vpcs = {
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf
       # Value of `nacl` must match key of objects stored in `nacls`
-      "10.100.0.0/24"  = { az = "eu-central-1a", set = "mgmt", nacl = null }
-      "10.100.64.0/24" = { az = "eu-central-1b", set = "mgmt", nacl = null }
-      "10.100.1.0/24"  = { az = "eu-central-1a", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.65.0/24" = { az = "eu-central-1b", set = "private", nacl = "trusted_path_monitoring" }
-      "10.100.2.0/24"  = { az = "eu-central-1a", set = "public", nacl = null }
-      "10.100.66.0/24" = { az = "eu-central-1b", set = "public", nacl = null }
-      "10.100.5.0/24"  = { az = "eu-central-1a", set = "gwlb", nacl = null }
-      "10.100.69.0/24" = { az = "eu-central-1b", set = "gwlb", nacl = null }
+      "10.100.0.0/24"  = { az = "eu-west-1a", set = "mgmt", nacl = null }
+      "10.100.64.0/24" = { az = "eu-west-1b", set = "mgmt", nacl = null }
+      "10.100.1.0/24"  = { az = "eu-west-1a", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.65.0/24" = { az = "eu-west-1b", set = "private", nacl = "trusted_path_monitoring" }
+      "10.100.2.0/24"  = { az = "eu-west-1a", set = "public", nacl = null }
+      "10.100.66.0/24" = { az = "eu-west-1b", set = "public", nacl = null }
+      "10.100.5.0/24"  = { az = "eu-west-1a", set = "gwlb", nacl = null }
+      "10.100.69.0/24" = { az = "eu-west-1b", set = "gwlb", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -234,12 +234,12 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.104.0.0/24"   = { az = "eu-central-1a", set = "app1_vm", nacl = null }
-      "10.104.128.0/24" = { az = "eu-central-1b", set = "app1_vm", nacl = null }
-      "10.104.2.0/24"   = { az = "eu-central-1a", set = "app1_lb", nacl = null }
-      "10.104.130.0/24" = { az = "eu-central-1b", set = "app1_lb", nacl = null }
-      "10.104.3.0/24"   = { az = "eu-central-1a", set = "app1_gwlbe", nacl = null }
-      "10.104.131.0/24" = { az = "eu-central-1b", set = "app1_gwlbe", nacl = null }
+      "10.104.0.0/24"   = { az = "eu-west-1a", set = "app1_vm", nacl = null }
+      "10.104.128.0/24" = { az = "eu-west-1b", set = "app1_vm", nacl = null }
+      "10.104.2.0/24"   = { az = "eu-west-1a", set = "app1_lb", nacl = null }
+      "10.104.130.0/24" = { az = "eu-west-1b", set = "app1_lb", nacl = null }
+      "10.104.3.0/24"   = { az = "eu-west-1a", set = "app1_gwlbe", nacl = null }
+      "10.104.131.0/24" = { az = "eu-west-1b", set = "app1_gwlbe", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -318,12 +318,12 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf.
-      "10.105.0.0/24"   = { az = "eu-central-1a", set = "app2_vm", nacl = null }
-      "10.105.128.0/24" = { az = "eu-central-1b", set = "app2_vm", nacl = null }
-      "10.105.2.0/24"   = { az = "eu-central-1a", set = "app2_lb", nacl = null }
-      "10.105.130.0/24" = { az = "eu-central-1b", set = "app2_lb", nacl = null }
-      "10.105.3.0/24"   = { az = "eu-central-1a", set = "app2_gwlbe", nacl = null }
-      "10.105.131.0/24" = { az = "eu-central-1b", set = "app2_gwlbe", nacl = null }
+      "10.105.0.0/24"   = { az = "eu-west-1a", set = "app2_vm", nacl = null }
+      "10.105.128.0/24" = { az = "eu-west-1b", set = "app2_vm", nacl = null }
+      "10.105.2.0/24"   = { az = "eu-west-1a", set = "app2_lb", nacl = null }
+      "10.105.130.0/24" = { az = "eu-west-1b", set = "app2_lb", nacl = null }
+      "10.105.3.0/24"   = { az = "eu-west-1a", set = "app2_gwlbe", nacl = null }
+      "10.105.131.0/24" = { az = "eu-west-1b", set = "app2_gwlbe", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -412,8 +412,8 @@ vmseries_asgs = {
         device_index   = 0
         security_group = "vmseries_private"
         subnet = {
-          "privatea" = "eu-central-1a",
-          "privateb" = "eu-central-1b"
+          "privatea" = "eu-west-1a",
+          "privateb" = "eu-west-1b"
         }
         create_public_ip  = false
         source_dest_check = false
@@ -422,8 +422,8 @@ vmseries_asgs = {
         device_index   = 1
         security_group = "vmseries_mgmt"
         subnet = {
-          "mgmta" = "eu-central-1a",
-          "mgmtb" = "eu-central-1b"
+          "mgmta" = "eu-west-1a",
+          "mgmtb" = "eu-west-1b"
         }
         create_public_ip  = true
         source_dest_check = true
@@ -432,8 +432,8 @@ vmseries_asgs = {
         device_index   = 2
         security_group = "vmseries_public"
         subnet = {
-          "publica" = "eu-central-1a",
-          "publicb" = "eu-central-1b"
+          "publica" = "eu-west-1a",
+          "publicb" = "eu-west-1b"
         }
         create_public_ip  = true
         source_dest_check = false
@@ -485,28 +485,28 @@ panorama_connection = {
 ### SPOKE VMS
 spoke_vms = {
   "app1_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app1_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app1_vpc"
     vpc_subnet     = "app1_vpc-app1_vm"
     security_group = "app1_vm"
     type           = "t2.micro"
   }
   "app2_vm01" = {
-    az             = "eu-central-1a"
+    az             = "eu-west-1a"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"
     type           = "t2.micro"
   }
   "app2_vm02" = {
-    az             = "eu-central-1b"
+    az             = "eu-west-1b"
     vpc            = "app2_vpc"
     vpc_subnet     = "app2_vpc-app2_vm"
     security_group = "app2_vm"

--- a/examples/isolated_design_autoscale/example.tfvars
+++ b/examples/isolated_design_autoscale/example.tfvars
@@ -1,6 +1,6 @@
 ### GENERAL
 region      = "eu-west-1" # TODO: update here
-name_prefix = "example-"     # TODO: update here
+name_prefix = "example-"  # TODO: update here
 
 global_tags = {
   ManagedBy   = "terraform"

--- a/examples/panorama_standalone/example.tfvars
+++ b/examples/panorama_standalone/example.tfvars
@@ -1,5 +1,5 @@
 ### General
-region      = "eu-central-1" # TODO: update here
+region      = "eu-west-1" # TODO: update here
 name_prefix = "example-"     # TODO: update here
 
 global_tags = {
@@ -40,8 +40,8 @@ vpcs = {
     }
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf
-      "10.255.0.0/24" = { az = "eu-central-1a", set = "mgmt" }
-      "10.255.1.0/24" = { az = "eu-central-1b", set = "mgmt" }
+      "10.255.0.0/24" = { az = "eu-west-1a", set = "mgmt" }
+      "10.255.1.0/24" = { az = "eu-west-1b", set = "mgmt" }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -62,11 +62,11 @@ panoramas = {
   panorama_ha_pair = {
     instances = {
       "primary" = {
-        az                 = "eu-central-1a"
+        az                 = "eu-west-1a"
         private_ip_address = "10.255.0.4"
       }
       "secondary" = {
-        az                 = "eu-central-1b"
+        az                 = "eu-west-1b"
         private_ip_address = "10.255.1.4"
       }
     }

--- a/examples/panorama_standalone/example.tfvars
+++ b/examples/panorama_standalone/example.tfvars
@@ -1,6 +1,6 @@
 ### General
 region      = "eu-west-1" # TODO: update here
-name_prefix = "example-"     # TODO: update here
+name_prefix = "example-"  # TODO: update here
 
 global_tags = {
   ManagedBy   = "terraform"

--- a/examples/vmseries_standalone/example.tfvars
+++ b/examples/vmseries_standalone/example.tfvars
@@ -1,6 +1,6 @@
 ### GENERAL
 region      = "eu-west-1" # TODO: update here
-name_prefix = "example-"     # TODO: update here
+name_prefix = "example-"  # TODO: update here
 
 global_tags = {
   ManagedBy   = "terraform"

--- a/examples/vmseries_standalone/example.tfvars
+++ b/examples/vmseries_standalone/example.tfvars
@@ -1,5 +1,5 @@
 ### GENERAL
-region      = "eu-central-1" # TODO: update here
+region      = "eu-west-1" # TODO: update here
 name_prefix = "example-"     # TODO: update here
 
 global_tags = {
@@ -42,7 +42,7 @@ vpcs = {
     subnets = {
       # Do not modify value of `set=`, it is an internal identifier referenced by main.tf
       # Value of `nacl` must match key of objects stored in `nacls`
-      "10.100.0.0/24" = { az = "eu-central-1a", set = "mgmt", nacl = null }
+      "10.100.0.0/24" = { az = "eu-west-1a", set = "mgmt", nacl = null }
     }
     routes = {
       # Value of `vpc_subnet` is built from key of VPCs concatenate with `-` and key of subnet in format: `VPCKEY-SUBNETKEY`
@@ -62,7 +62,7 @@ vpcs = {
 vmseries = {
   vmseries = {
     instances = {
-      "01" = { az = "eu-central-1a" }
+      "01" = { az = "eu-west-1a" }
     }
 
     # Value of `panorama-server`, `auth-key`, `dgname`, `tplname` can be taken from plugin `sw_fw_license`


### PR DESCRIPTION
## Description

During release there was an error in `eu-central-1` region. Even when we specify TGW attachment with enabled appliance mode support, attachment is created with disabled value. Then while checking idempotence Terratest propose to change it into `enable` as it's defined in default value for `appliance_mode_support`:

```
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:   # module.transit_gateway_attachment["app1"].aws_ec2_transit_gateway_vpc_attachment.this will be updated in-place
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:   ~ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:       ~ appliance_mode_support                          = "disable" -> "enable"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         id                                              = "tgw-attach-0f219e9c790aa6aee"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         tags                                            = {
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:             "Name" = "tt-42b8-app1-spoke-vpc"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         }
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         # (9 unchanged attributes hidden)
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:     }
  TestIdempotence 2023-10-12T04:43:08Z command.go:185: 
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:   # module.transit_gateway_attachment["app2"].aws_ec2_transit_gateway_vpc_attachment.this will be updated in-place
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:   ~ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:       ~ appliance_mode_support                          = "disable" -> "enable"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         id                                              = "tgw-attach-05adc27b67c0e7698"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         tags                                            = {
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:             "Name" = "tt-42b8-app2-spoke-vpc"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         }
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         # (9 unchanged attributes hidden)
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:     }
  TestIdempotence 2023-10-12T04:43:08Z command.go:185: 
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:   # module.transit_gateway_attachment["security"].aws_ec2_transit_gateway_vpc_attachment.this will be updated in-place
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:   ~ resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:       ~ appliance_mode_support                          = "disable" -> "enable"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         id                                              = "tgw-attach-09b2a15315de25671"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         tags                                            = {
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:             "Name" = "tt-42b8-vmseries"
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         }
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:         # (9 unchanged attributes hidden)
  TestIdempotence 2023-10-12T04:43:08Z command.go:185:     }
```

While testing the same example in different regions e.g. `us-east-1` or `eu-west-1` there is no issue and TGW attachment is created with enabled appliance support (as it's defined in default value for `appliance_mode_support`).

It seems to be a bug in `eu-central-1` region, so PRs delivers change of region for examples from `eu-central-1` to `eu-west-1` in order to successfully created release package.

## Motivation and Context

There was an issue while doing release: https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/actions/runs/6490065707

## How Has This Been Tested?

Code was tested via ChatOps (see comments in PR).

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
