### PR TITLE
docs: adjust modules readme headers for pan.dev

### DIFF
--- a/modules/crosszone_failover/README.md
+++ b/modules/crosszone_failover/README.md
@@ -2,6 +2,7 @@
 
 A Terraform module for deploying a Crosszone Failover for VM-Series firewalls.
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ### Requirements
 
@@ -64,4 +65,4 @@ No modules.
 ### Outputs
 
 No outputs.
-#<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpc_endpoint/README.md
+++ b/modules/vpc_endpoint/README.md
@@ -2,6 +2,7 @@
 
 A Terraform module for deploying a VPC Endpoint for VM-Series firewalls.
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ### Requirements
 
@@ -53,4 +54,4 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | The created `aws_vpc_endpoint` object. Alternatively, the data resource if the input `create` is false. |
-#<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpn/README.md
+++ b/modules/vpn/README.md
@@ -2,6 +2,7 @@
 
 A Terraform module for deploying a VPN for VM-Series firewalls.
 
+## Reference
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ### Requirements
 


### PR DESCRIPTION
## Description

Adjust crosszone_failover, vpc_endpoint, vpn modules README headers to display nicely on pan.dev
There has been extra # chars in the beginning and end of reference sections.

## Screenshots (if appropriate)

Extra char before reference section:
![image](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/assets/6500664/c41f4f2c-2c77-4e6b-95ee-5aaf20fbc770)

Extra char in the EOF:
![image](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/assets/6500664/7fa070c9-9fdd-41c3-ae33-aba5559de8a7)
