### PR TITLE
fix(module/asg): Execute pip to install Python packages (corner case in CI/CD pipeline)

### DIFF
--- a/modules/asg/main.tf
+++ b/modules/asg/main.tf
@@ -243,7 +243,7 @@ EOF
 # https://docs.aws.amazon.com/lambda/latest/dg/python-package.html
 resource "null_resource" "python_requirements" {
   triggers = {
-    installed-pan-os-python = fileexists("${path.module}/scripts/pan_os_python-1.11.0.dist-info/METADATA") || var.lambda_execute_pip_install_once
+    installed-pan-os-python = fileexists("${path.module}/scripts/pan_os_python-1.11.0.dist-info/METADATA") || var.lambda_execute_pip_install_once ? true : timestamp()
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Description

PR delivers fix for one corner case while executing Terraform code in CI/CD pipelines.

## Motivation and Context

If Terraform code is executed in CI/CD pipeline, then:
- after first `terraform apply` whole infrastructure is being deployed and while installing Lambda, locally on agent executing pipeline there are downloaded Python packages and `installed-pan-os-python` is set from `known after apply` to `false`
- next time when CI/CD pipeline is executed on different agent, `terraform apply` will not install Python packages, because there is no change for `installed-pan-os-python`, it's still `false` as local Python packages are not existing on new agent
- Lambda is being deploying without required Python packages

PR changes that behaviour - instead of using `false`, when there are no Python packages, we are using `timestamp()`, which forces to execute `pip install` every time, when there are no Python packages.

## How Has This Been Tested?

Code was tested locally by:
- deploying `examples/centralized_design_autoscale`
- manually removing all Python packages from `modules/asg/scripts`, stored on local disk
- executing `terraform apply` one more time for `examples/centralized_design_autoscale`
- checking in AWS console if Lambda contains all Python packages after every `terraform apply`

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
