### PR TITLE
fix(module/asg): In Lambda KeyError: 'SubnetId' should not be raised after manual EC2 instance termination

### DIFF
--- a/modules/asg/scripts/lambda.py
+++ b/modules/asg/scripts/lambda.py
@@ -177,8 +177,8 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
         """
 
         instance_info = self.ec2_client.describe_instances(InstanceIds=[instance_id])['Reservations'][0]['Instances'][0]
-        return instance_info['Placement']['AvailabilityZone'], instance_info['SubnetId'], \
-               instance_info['NetworkInterfaces']
+        return instance_info.get('Placement').get('AvailabilityZone'), instance_info.get('SubnetId'), \
+               instance_info.get('NetworkInterfaces')
 
     def create_network_interface(self, instance_id: str, subnet_id: str, sg_id: int) -> str:
         """

--- a/modules/asg/scripts/lambda.py
+++ b/modules/asg/scripts/lambda.py
@@ -177,8 +177,8 @@ class VMSeriesInterfaceScaling(ConfigureLogger):
         """
 
         instance_info = self.ec2_client.describe_instances(InstanceIds=[instance_id])['Reservations'][0]['Instances'][0]
-        return instance_info.get('Placement').get('AvailabilityZone'), instance_info.get('SubnetId'), \
-               instance_info.get('NetworkInterfaces')
+        return instance_info.get('Placement').get('AvailabilityZone') if 'Placement' in instance_info else None, \
+            instance_info.get('SubnetId'), instance_info.get('NetworkInterfaces')
 
     def create_network_interface(self, instance_id: str, subnet_id: str, sg_id: int) -> str:
         """


### PR DESCRIPTION
## Description

PR delivers change in acquiring EC2 instance info - in function `inspect_ec2_instance()` method [`get()`](https://docs.python.org/3.8/library/stdtypes.html) was used to return the value for keys. In comparison to previous approach, if key isn't in the dictionary, then `get()` returns default. If default is not given, it defaults to `None`, so that this method never raises a [KeyError](https://docs.python.org/3.8/library/exceptions.html#KeyError).

Finally - using new approach while manually terminating EC2 instance in AWS console, Lambda doesn't release elastic IP or deregister IP of the instance from target group, but at least it's executed only once. Previously Lambda was failing with `KeyError: 'SubnetId'` and it was executed multiple times after EC2 instance was terminated manually. 

## Motivation and Context

In previous approach while manually terminating EC2 instance from AWS console, Lambda during invocation was throwing errors:

```
  | 2023-12-22T09:13:06.462+01:00 | START RequestId: 07dc21dc-b928-4b27-bdd6-d161ea9942f8 Version: $LATEST
  | 2023-12-22T09:13:06.985+01:00 [ERROR] KeyError: 'SubnetId'Traceback (most recent call last):  File "/var/task/lambda.py", line 591, in lambda_handler    VMSeriesInterfaceScaling(asg_event)  File "/var/task/lambda.py", line 36, in __init__    self.main(asg_event)  File "/var/task/lambda.py", line 47, in main    instance_zone, subnet_id, network_interfaces = self.inspect_ec2_instance(instance_id)  File "/var/task/lambda.py", line 180, in inspect_ec2_instance    return instance_info['Placement']['AvailabilityZone'], instance_info['SubnetId'], \ | [ERROR] KeyError: 'SubnetId' Traceback (most recent call last):   File "/var/task/lambda.py", line 591, in lambda_handler     VMSeriesInterfaceScaling(asg_event)   File "/var/task/lambda.py", line 36, in __init__     self.main(asg_event)   File "/var/task/lambda.py", line 47, in main     instance_zone, subnet_id, network_interfaces = self.inspect_ec2_instance(instance_id)   File "/var/task/lambda.py", line 180, in inspect_ec2_instance     return instance_info['Placement']['AvailabilityZone'], instance_info['SubnetId'], \
  | 2023-12-22T09:13:07.022+01:00 | END RequestId: 07dc21dc-b928-4b27-bdd6-d161ea9942f8
```

Moreover Lambada invoked by ASG lifecycle hook is executed unnecessarily multiple times.

After changing approach to use `get()` method, in case of manual EC2 instance termination from AWS console, Lambda is executed only once and without `KeyError`:

```

  | 2023-12-22T10:50:53.924+01:00 | START RequestId: 758b7729-e36c-4794-bd89-686183353df3 Version: $LATEST
  | 2023-12-22T10:50:54.470+01:00 | [INFO] 2023-12-22T09:50:54.470Z 758b7729-e36c-4794-bd89-686183353df3 Run cleanup mode.
  | 2023-12-22T10:50:54.470+01:00 | [INFO] 2023-12-22T09:50:54.470Z 758b7729-e36c-4794-bd89-686183353df3 Search for interfaces with EIP on i-0557bede99ddd8a15
  | 2023-12-22T10:50:54.470+01:00 | [INFO] 2023-12-22T09:50:54.470Z 758b7729-e36c-4794-bd89-686183353df3 Not found any interfaces with EIP
  | 2023-12-22T10:50:54.531+01:00 | [INFO] 2023-12-22T09:50:54.530Z 758b7729-e36c-4794-bd89-686183353df3 Deregister target with IP None in target group arn:aws:elasticloadbalancing:eu-central-1:751512424814:targetgroup/sczcen-public-alb-app1-8081/776533ca3fc9c566
  | 2023-12-22T10:50:54.531+01:00 | [ERROR] 2023-12-22T09:50:54.531Z 758b7729-e36c-4794-bd89-686183353df3 Unable to deregister target with IP None
  | 2023-12-22T10:50:54.531+01:00 | [INFO] 2023-12-22T09:50:54.531Z 758b7729-e36c-4794-bd89-686183353df3 Deregister target with IP None in target group arn:aws:elasticloadbalancing:eu-central-1:751512424814:targetgroup/sczcen-public-alb-app2-8082/213b64644ede0ba8
  | 2023-12-22T10:50:54.532+01:00 | [ERROR] 2023-12-22T09:50:54.532Z 758b7729-e36c-4794-bd89-686183353df3 Unable to deregister target with IP None
  | 2023-12-22T10:50:54.532+01:00 | [INFO] 2023-12-22T09:50:54.532Z 758b7729-e36c-4794-bd89-686183353df3 Deregister target with IP None in target group arn:aws:elasticloadbalancing:eu-central-1:751512424814:targetgroup/sczcen-public-nlb-ssh1/906bf6bb90020909
  | 2023-12-22T10:50:54.532+01:00 | [ERROR] 2023-12-22T09:50:54.532Z 758b7729-e36c-4794-bd89-686183353df3 Unable to deregister target with IP None
  | 2023-12-22T10:50:54.532+01:00 | [INFO] 2023-12-22T09:50:54.532Z 758b7729-e36c-4794-bd89-686183353df3 Deregister target with IP None in target group arn:aws:elasticloadbalancing:eu-central-1:751512424814:targetgroup/sczcen-public-nlb-ssh2/85e4eff80a0e15fe
  | 2023-12-22T10:50:54.532+01:00 | [ERROR] 2023-12-22T09:50:54.532Z 758b7729-e36c-4794-bd89-686183353df3 Unable to deregister target with IP None
  | 2023-12-22T10:50:54.532+01:00 | [DEBUG] 2023-12-22T09:50:54.532Z 758b7729-e36c-4794-bd89-686183353df3 DEBUG: complete
  | 2023-12-22T10:50:54.870+01:00 | END RequestId: 758b7729-e36c-4794-bd89-686183353df3
```

Of course it doesn't change the fact, that still while manually terminating EC2 instance we cannot release elastic IP and deregister instance from target groups for load balancers. In order to properly terminate instance working in ASG we can change desired number of EC2 instances - it can be achieved in AWS console or by changing Terraform code https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/blob/5fbca48d51b5bf8817c02623a7a1129679ac1839/examples/centralized_design_autoscale/example.tfvars#L561-L566

While terminating instance by changing desired capacity, Lambda is properly terminating instance, releasing elastic IP and deregistering IP from target group for load balancers:

```

  | 2023-12-22T11:54:30.606+01:00 | START RequestId: 52580173-45e9-478a-9660-5d99776f2f16 Version: $LATEST
  | 2023-12-22T11:54:34.105+01:00 | [INFO] 2023-12-22T10:54:34.105Z 52580173-45e9-478a-9660-5d99776f2f16 Run cleanup mode.
  | 2023-12-22T11:54:34.105+01:00 | [INFO] 2023-12-22T10:54:34.105Z 52580173-45e9-478a-9660-5d99776f2f16 Search for interfaces with EIP on i-096fc2cbb18a4fd12
  | 2023-12-22T11:54:34.105+01:00 | [INFO] 2023-12-22T10:54:34.105Z 52580173-45e9-478a-9660-5d99776f2f16 Found interfaces with EIP 35.156.167.186
  | 2023-12-22T11:54:35.601+01:00 | [INFO] 2023-12-22T10:54:35.600Z 52580173-45e9-478a-9660-5d99776f2f16 Successfully release 35.156.167.186
  | 2023-12-22T11:54:35.601+01:00 | [INFO] 2023-12-22T10:54:35.601Z 52580173-45e9-478a-9660-5d99776f2f16 Found interfaces with EIP 3.65.80.181
  | 2023-12-22T11:54:37.076+01:00 | [INFO] 2023-12-22T10:54:37.076Z 52580173-45e9-478a-9660-5d99776f2f16 Successfully release 3.65.80.181
  | 2023-12-22T11:54:37.181+01:00 | [INFO] 2023-12-22T10:54:37.181Z 52580173-45e9-478a-9660-5d99776f2f16 Deregister target with IP 10.100.66.251 in target group arn:aws:elasticloadbalancing:eu-central-1:751512424814:targetgroup/sczcen-public-alb-app1-8081/776533ca3fc9c566
  | 2023-12-22T11:54:37.402+01:00 | [INFO] 2023-12-22T10:54:37.402Z 52580173-45e9-478a-9660-5d99776f2f16 Deregister target with IP 10.100.66.251 in target group arn:aws:elasticloadbalancing:eu-central-1:751512424814:targetgroup/sczcen-public-alb-app2-8082/213b64644ede0ba8
  | 2023-12-22T11:54:37.482+01:00 | [INFO] 2023-12-22T10:54:37.482Z 52580173-45e9-478a-9660-5d99776f2f16 Deregister target with IP 10.100.66.251 in target group arn:aws:elasticloadbalancing:eu-central-1:751512424814:targetgroup/sczcen-public-nlb-ssh1/906bf6bb90020909
  | 2023-12-22T11:54:37.589+01:00 | [INFO] 2023-12-22T10:54:37.589Z 52580173-45e9-478a-9660-5d99776f2f16 Deregister target with IP 10.100.66.251 in target group arn:aws:elasticloadbalancing:eu-central-1:751512424814:targetgroup/sczcen-public-nlb-ssh2/85e4eff80a0e15fe
  | 2023-12-22T11:54:37.677+01:00 | [DEBUG] 2023-12-22T10:54:37.677Z 52580173-45e9-478a-9660-5d99776f2f16 DEBUG: complete
  | 2023-12-22T11:54:38.044+01:00 | END RequestId: 52580173-45e9-478a-9660-5d99776f2f16


```

## How Has This Been Tested?

Code was tested by deploying [centralized_design_autoscale example](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/tree/main/examples/centralized_design_autoscale).

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
